### PR TITLE
Field coords

### DIFF
--- a/stagpy/config.py
+++ b/stagpy/config.py
@@ -104,7 +104,7 @@ CONF_DEF['field'] = OrderedDict((
     ('shift', Conf(None, True, None, {'type': int},
                    False, 'shift plot horizontally')),
     ('timelabel', switch_opt(False, None, 'add label with time')),
-    ('interpolate', switch_opt(True, None, 'apply Gouraud shading')),
+    ('interpolate', switch_opt(False, None, 'apply Gouraud shading')),
     ('colorbar', switch_opt(True, None, 'add color bar to plot')),
     ('ix', Conf(None, True, None, {'type': int},
                 False, 'x-index of slice for 3D fields')),

--- a/stagpy/field.py
+++ b/stagpy/field.py
@@ -13,8 +13,12 @@ from .error import NotAvailableError
 from .stagyydata import StagyyData
 
 
+# The location is off for vertical velocities they have an extra
+# point in (x,y) instead of z in the output
+
+
 def _threed_extract(step, var):
-    """Return suitable slices and mesh for 3D fields."""
+    """Return suitable slices and coords for 3D fields."""
     is_vector = not valid_field_var(var)
     i_x = conf.field.ix
     i_y = conf.field.iy
@@ -26,15 +30,18 @@ def _threed_extract(step, var):
     if i_x is None and i_y is None and i_z is None:
         i_x = 0
     if i_x is not None:
-        xmesh, ymesh = step.geom.y_mesh[i_x, :, :], step.geom.z_mesh[i_x, :, :]
+        xcoord = step.geom.y_walls if is_vector else step.geom.y_centers
+        ycoord = step.geom.z_centers
         i_y = i_z = slice(None)
         varx, vary = var + '2', var + '3'
     elif i_y is not None:
-        xmesh, ymesh = step.geom.x_mesh[:, i_y, :], step.geom.z_mesh[:, i_y, :]
+        xcoord = step.geom.x_walls if is_vector else step.geom.x_centers
+        ycoord = step.geom.z_centers
         i_x = i_z = slice(None)
         varx, vary = var + '1', var + '3'
     else:
-        xmesh, ymesh = step.geom.x_mesh[:, :, i_z], step.geom.y_mesh[:, :, i_z]
+        xcoord = step.geom.x_walls if is_vector else step.geom.x_centers
+        ycoord = step.geom.y_walls if is_vector else step.geom.y_centers
         i_x = i_y = slice(None)
         varx, vary = var + '1', var + '2'
     if is_vector:
@@ -42,7 +49,7 @@ def _threed_extract(step, var):
                 step.fields[vary][i_x, i_y, i_z, 0])
     else:
         data = step.fields[var][i_x, i_y, i_z, 0]
-    return (xmesh, ymesh), data
+    return (xcoord, ycoord), data
 
 
 def valid_field_var(var):
@@ -74,17 +81,23 @@ def get_meshes_fld(step, var):
             the value of the requested field.
     """
     fld = step.fields[var]
+    is_vector = (fld.shape[0] != step.geom.nxtot or
+                 fld.shape[1] != step.geom.nytot)
     if step.geom.threed and step.geom.cartesian:
-        (xmesh, ymesh), fld = _threed_extract(step, var)
+        (xcoord, ycoord), fld = _threed_extract(step, var)
     elif step.geom.twod_xz:
-        xmesh, ymesh = step.geom.x_mesh[:, 0, :], step.geom.z_mesh[:, 0, :]
+        xcoord = step.geom.x_walls if is_vector else step.geom.x_centers
+        ycoord = step.geom.z_centers
         fld = fld[:, 0, :, 0]
-    elif step.geom.cartesian and step.geom.twod_yz:
-        xmesh, ymesh = step.geom.y_mesh[0, :, :], step.geom.z_mesh[0, :, :]
+    else:  # twod_yz
+        xcoord = step.geom.y_walls if is_vector else step.geom.y_centers
+        ycoord = step.geom.z_centers
+        if step.geom.curvilinear:
+            pmesh, rmesh = np.meshgrid(xcoord, ycoord, indexing='ij')
+            xmesh, ymesh = rmesh * np.cos(pmesh), rmesh * np.sin(pmesh)
         fld = fld[0, :, :, 0]
-    else:  # spherical yz
-        xmesh, ymesh = step.geom.x_mesh[0, :, :], step.geom.y_mesh[0, :, :]
-        fld = fld[0, :, :, 0]
+    if step.geom.cartesian:
+        xmesh, ymesh = np.meshgrid(xcoord, ycoord, indexing='ij')
     return xmesh, ymesh, fld
 
 
@@ -103,22 +116,27 @@ def get_meshes_vec(step, var):
             component and y component of the requested vector field.
     """
     if step.geom.threed and step.geom.cartesian:
-        (xmesh, ymesh), (vec1, vec2) = _threed_extract(step, var)
+        (xcoord, ycoord), (vec1, vec2) = _threed_extract(step, var)
     elif step.geom.twod_xz:
-        xmesh, ymesh = step.geom.x_mesh[:, 0, :], step.geom.z_mesh[:, 0, :]
+        xcoord, ycoord = step.geom.x_walls, step.geom.z_centers
         vec1 = step.fields[var + '1'][:, 0, :, 0]
         vec2 = step.fields[var + '3'][:, 0, :, 0]
     elif step.geom.cartesian and step.geom.twod_yz:
-        xmesh, ymesh = step.geom.y_mesh[0, :, :], step.geom.z_mesh[0, :, :]
+        xcoord, ycoord = step.geom.y_walls, step.geom.z_centers
         vec1 = step.fields[var + '2'][0, :, :, 0]
         vec2 = step.fields[var + '3'][0, :, :, 0]
     else:  # spherical yz
-        xmesh, ymesh = step.geom.x_mesh[0, :, :], step.geom.y_mesh[0, :, :]
-        pmesh = step.geom.p_mesh[0, :, :]
+        pcoord = step.geom.p_walls
+        pmesh = np.outer(pcoord, np.ones(step.geom.nrtot))
         vec_phi = step.fields[var + '2'][0, :, :, 0]
         vec_r = step.fields[var + '3'][0, :, :, 0]
         vec1 = vec_r * np.cos(pmesh) - vec_phi * np.sin(pmesh)
         vec2 = vec_phi * np.cos(pmesh) + vec_r * np.sin(pmesh)
+        pcoord, rcoord = step.geom.p_walls, step.geom.r_centers
+        pmesh, rmesh = np.meshgrid(pcoord, rcoord, indexing='ij')
+        xmesh, ymesh = rmesh * np.cos(pmesh), rmesh * np.sin(pmesh)
+    if step.geom.cartesian:
+        xmesh, ymesh = np.meshgrid(xcoord, ycoord, indexing='ij')
     return xmesh, ymesh, vec1, vec2
 
 
@@ -179,7 +197,7 @@ def plot_scalar(step, var, field=None, axis=None, **extra):
         xmin = -xmax
         ymin = -ymax
         rsurf = xmax if step.timeinfo['thick_tmo'] > 0 \
-            else step.geom.r_mesh[0, 0, -3]
+            else step.geom.r_walls[0, 0, -3]
         cmb = mpat.Circle((0, 0), rcmb, color='dimgray', zorder=0)
         psurf = mpat.Circle((0, 0), rsurf, color='indianred', zorder=0)
         axis.add_patch(psurf)

--- a/stagpy/processing.py
+++ b/stagpy/processing.py
@@ -280,12 +280,12 @@ def stream_function(step):
         x-direction, y-direction, z-direction and block.
     """
     if step.geom.twod_yz:
-        x_coord = step.geom.y_coord
+        x_coord = step.geom.y_walls
         v_x = step.fields['v2'][0, :, :, 0]
         v_z = step.fields['v3'][0, :, :, 0]
         shape = (1, v_x.shape[0], v_x.shape[1], 1)
     elif step.geom.twod_xz and step.geom.cartesian:
-        x_coord = step.geom.x_coord
+        x_coord = step.geom.x_walls
         v_x = step.fields['v1'][:, 0, :, 0]
         v_z = step.fields['v3'][:, 0, :, 0]
         shape = (v_x.shape[0], 1, v_x.shape[1], 1)
@@ -295,8 +295,8 @@ def stream_function(step):
     psi = np.zeros_like(v_x)
     if step.geom.spherical:  # YZ annulus
         # positions
-        r_nc = step.geom.r_coord  # numerical centers
-        r_pc = step.geom.r_mesh[0, 0, :]  # physical centers
+        r_nc = step.rprofs.centers  # numerical centers
+        r_pc = step.geom.r_centers  # physical centers
         r_nw = step.rprofs.walls[:2]  # numerical walls of first cell
         # vz at center of bottom cells
         vz0 = ((r_nw[1] - r_nc[0]) * v_z[:, 0] +
@@ -308,7 +308,7 @@ def stream_function(step):
             psi[i_x, 1:] = psi[i_x, 0] + \
                 integrate.cumtrapz(r_pc * vxc[i_x], x=r_nc)
     else:  # assume cartesian geometry
-        z_nc = step.geom.z_coord
+        z_nc = step.geom.r_centers
         z_nw = step.rprofs.walls[:2]
         vz0 = ((z_nw[1] - z_nc[0]) * v_z[:, 0] +
                (z_nc[0] - z_nw[0]) * v_z[:, 1]) / (z_nw[1] - z_nw[0])

--- a/stagpy/stagyyparsers.py
+++ b/stagpy/stagyyparsers.py
@@ -369,6 +369,10 @@ def fields(fieldfile, only_header=False, only_istep=False):
             sfield = True
 
         magic %= 100
+        if magic < 9:
+            # the rest of the parser still check lower values in case this
+            # constraint is alleviated
+            raise ParsingError(fieldfile, 'magic < 9 not supported')
 
         # extra ghost point in horizontal direction
         header['xyp'] = int(magic >= 9 and nval == 4)
@@ -412,10 +416,6 @@ def fields(fieldfile, only_header=False, only_istep=False):
             header['e1_coord'] = readbin('f', header['nts'][0])
             header['e2_coord'] = readbin('f', header['nts'][1])
             header['e3_coord'] = readbin('f', header['nts'][2])
-        else:
-            # could construct them from other info
-            raise ParsingError(fieldfile,
-                               'magic >= 4 expected to get grid geometry')
 
         if only_header:
             return header
@@ -609,8 +609,6 @@ def _read_coord_h5(files, shapes, header, twod):
     header['nts'] = list((meshes[0]['X'].shape[i] - 1) * header['ncs'][i]
                          for i in range(3))
     header['nts'] = np.array([max(1, val) for val in header['nts']])
-    # meshes could also be defined in legacy parser, so that these can be used
-    # in geometry setup
     meshes = _conglomerate_meshes(meshes, header)
     if np.any(meshes['Z'][:, :, 0] != 0):
         # spherical

--- a/stagpy/stagyyparsers.py
+++ b/stagpy/stagyyparsers.py
@@ -656,9 +656,7 @@ def _get_field(xdmf_file, data_item):
     shp = _get_dim(data_item)
     h5file, group = data_item.text.strip().split(':/', 1)
     # Field on yin is named <var>_XXXXX_YYYYY, on yang is <var>2XXXXX_YYYYY.
-    # This splitting is done to protect against that and <var> possibly
-    # containing a 2.
-    numeral_part = group.split('2')[-1]
+    numeral_part = group[-11:]
     icore = int(numeral_part.split('_')[-2]) - 1
     fld = None
     try:

--- a/stagpy/stagyyparsers.py
+++ b/stagpy/stagyyparsers.py
@@ -370,12 +370,10 @@ def fields(fieldfile, only_header=False, only_istep=False):
 
         magic %= 100
         if magic < 9:
-            # the rest of the parser still check lower values in case this
-            # constraint is alleviated
             raise ParsingError(fieldfile, 'magic < 9 not supported')
 
         # extra ghost point in horizontal direction
-        header['xyp'] = int(magic >= 9 and nval == 4)
+        header['xyp'] = int(nval == 4)  # magic >= 9
 
         # total number of values in relevant space basis
         # (e1, e2, e3) = (theta, phi, radius) in spherical geometry
@@ -383,39 +381,35 @@ def fields(fieldfile, only_header=False, only_istep=False):
         header['nts'] = readbin(nwords=3)
 
         # number of blocks, 2 for yinyang or cubed sphere
-        header['ntb'] = readbin() if magic >= 7 else 1
+        header['ntb'] = readbin()  # magic >= 7
 
         # aspect ratio
         header['aspect'] = readbin('f', 2)
 
         # number of parallel subdomains
         header['ncs'] = readbin(nwords=3)  # (e1, e2, e3) space
-        header['ncb'] = readbin() if magic >= 8 else 1  # blocks
+        header['ncb'] = readbin()  # magic >= 8, blocks
 
         # r - coordinates
         # rgeom[0:self.nrtot+1, 0] are edge radial position
         # rgeom[0:self.nrtot, 1] are cell-center radial position
-        if magic >= 2:
-            header['rgeom'] = readbin('f', header['nts'][2] * 2 + 1)
-        else:
-            header['rgeom'] = np.array(range(0, header['nts'][2] * 2 + 1))\
-                * 0.5 / header['nts'][2]
+        header['rgeom'] = readbin('f', header['nts'][2] * 2 + 1)  # magic >= 2
         header['rgeom'] = np.resize(header['rgeom'], (header['nts'][2] + 1, 2))
 
-        header['rcmb'] = readbin('f') if magic >= 7 else None
+        header['rcmb'] = readbin('f')  # magic >= 7
 
-        header['ti_step'] = readbin() if magic >= 3 else 0
+        header['ti_step'] = readbin()  # magic >= 3
         if only_istep:
             return header['ti_step']
-        header['ti_ad'] = readbin('f') if magic >= 3 else 0
-        header['erupta_total'] = readbin('f') if magic >= 5 else 0
-        header['bot_temp'] = readbin('f') if magic >= 6 else 1
+        header['ti_ad'] = readbin('f')  # magic >= 3
+        header['erupta_total'] = readbin('f')  # magic >= 5
+        header['bot_temp'] = readbin('f')  # magic >= 6
         header['core_temp'] = readbin('f') if magic >= 10 else 1
 
-        if magic >= 4:
-            header['e1_coord'] = readbin('f', header['nts'][0])
-            header['e2_coord'] = readbin('f', header['nts'][1])
-            header['e3_coord'] = readbin('f', header['nts'][2])
+        # magic >= 4
+        header['e1_coord'] = readbin('f', header['nts'][0])
+        header['e2_coord'] = readbin('f', header['nts'][1])
+        header['e3_coord'] = readbin('f', header['nts'][2])
 
         if only_header:
             return header


### PR DESCRIPTION
This PR brings several improvements related to grid geometry.

- Geometry objects are now aware that cell centers and cell walls are different locations, `r_walls` and `r_centers` replace `r_coord` and similar for other directions.
- `r_mesh` and similar are dropped as they are memory consuming and not general (they were only defined for centers, and defining them for any combination of wall and center locations would lead to even more memory consumption).
- An extra layer was previously added to cell-centered fields in all geometry for the sole purpose to close the spherical annulus on plots; the used interpolation was only valid for wrapping boundary condition, and forced scripts to actively ignore that extra point. This PR removes that extra point.
- Interpolation when plotting scalar fields is disabled by default (but can be enabled through the `+interpolate` switch and the `conf.field.interpolate` configuration key) to avoid giving a sense that the run is more refined than it actually is.