### PR TITLE
New PossiblyCorruptedFileError exception

### DIFF
--- a/stagpy/_step.py
+++ b/stagpy/_step.py
@@ -280,7 +280,7 @@ class _Fields(Mapping):
     def __contains__(self, item):
         try:
             return self[item] is not None
-        except error.StagpyError:
+        except (error.MissingDataError, error.UnknownFieldVarError):
             return False
 
     def __len__(self):

--- a/stagpy/error.py
+++ b/stagpy/error.py
@@ -72,6 +72,10 @@ class ParsingError(StagpyError):
         super().__init__(faulty_file, msg)
 
 
+class PossiblyCorruptedFileError(ParsingError):
+    """Raised when file has non-sensical content."""
+
+
 class InvalidTimestepError(StagpyError, KeyError):
     """Raised when invalid time step is requested.
 


### PR DESCRIPTION
It is for now only raised when h5py fails with an OSError when
attempting to read a group.  The exception raised by h5py does not
contain information on the file nor the group it failed to read.  This
commit attempts to fix this problem by raising a bespoke exception for
this case.  Note that this hasn't strong guarantees to keep working in
the future as hdf5 doesn't consider error codes to be part of its API,
and h5py maps error codes to Python exceptions.

---

This supersedes #79, this PR handles only the exception of interest and
let the exception bubble up to be handled by the calling code. In particular,
when using the CLI, the user ends up with a clean error message consistent
with other `StagpyError`, and running with `STAGPY_DEBUG=1` shows the
error raised by `h5py` in the traceback.

@labrosse Please let me know whether you're happy with the behavior of
this branch (`corrupted-h5-file-error`).