### PR TITLE
Use tox-gh for CI on github actions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
+      fail-fast: false
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
 
@@ -26,8 +26,8 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Update pip
-        run: python3 -m pip install -U pip
-      - name: Install tox
-        run: python3 -m pip install tox
+        run: python -m pip install -U pip
+      - name: Install tox-gh
+        run: python -m pip install tox-gh
       - name: Run tox
-        run: python3 -m tox
+        run: tox4 run

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        py: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.py }}
       - name: Update pip
         run: python -m pip install -U pip
       - name: Install tox-gh

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,21 @@
 [tox]
-envlist = py37,py38,py39,py310,flake8,mypy
+envlist =
+    py37
+    py38
+    py39
+    py310
+    flake8
+    mypy
 skip_missing_interpreters = True
-skipsdist=True
 
 [testenv]
-usedevelop=True
 deps =
     pip>=20.2
     pytest>=6.0
     pytest-cov>=2.10
 commands =
     stagpy version
-    pytest --cov=stagpy --cov-report term-missing {posargs}
+    pytest --cov={envsitepackagesdir}/stagpy --cov-report term-missing {posargs}
 setenv = STAGPY_ISOLATED=True
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -50,3 +50,10 @@ per-file-ignores =
     setup.py:D
     tests/*:D
 max_complexity = 15
+
+[gh]
+python =
+    3.7 = py37, mypy
+    3.8 = py38, mypy
+    3.9 = py39, mypy
+    3.10 = py310, flake8, mypy


### PR DESCRIPTION
Note that even if `tox.ini` has been updated to work with `tox4`, it is still compatible with `tox3`.

This solves #83