### PR TITLE
Improve performances when reading tracers and fields with HDF5 output

### DIFF
--- a/stagpy/_step.py
+++ b/stagpy/_step.py
@@ -447,14 +447,10 @@ class _Tracers:
             self.step.sdat.filename("tra", timestep=self.step.isnap, force_legacy=True)
         )
         if data is None and self.step.sdat.hdf5:
-            position = any(axis not in self._data for axis in "xyz")
-            self._data.update(
-                stagyyparsers.read_tracers_h5(
-                    self.step.sdat.hdf5 / "DataTracers.xmf",
-                    name,
-                    self.step.isnap,
-                    position,
-                )
+            self._data[name] = stagyyparsers.read_tracers_h5(
+                self.step.sdat._traxmf,
+                name,
+                self.step.isnap,
             )
         elif data is not None:
             self._data.update(data)

--- a/stagpy/_step.py
+++ b/stagpy/_step.py
@@ -406,7 +406,7 @@ class _Fields(abc.Mapping):
         elif self.step.sdat.hdf5:
             header = stagyyparsers.read_geom_h5(
                 self.step.sdat._dataxmf, self.step.isnap
-            )[0]
+            )
         return header if header else None
 
     @cached_property

--- a/stagpy/_step.py
+++ b/stagpy/_step.py
@@ -367,16 +367,15 @@ class _Fields(abc.Mapping):
                 (stem, fvars) for stem, fvars in self._filesh5.items() if name in fvars
             ]
             for filestem, list_fvar in files:
+                sdat = self.step.sdat
                 if filestem in phyvars.SFIELD_FILES_H5:
-                    xmff = "Data{}.xmf".format(
-                        "Bottom" if name.endswith("bot") else "Surface"
-                    )
+                    xmff = sdat._botxmf if name.endswith("bot") else sdat._topxmf
                     header = self._header
                 else:
-                    xmff = "Data.xmf"
+                    xmff = sdat._dataxmf
                     header = None
                 parsed_data = stagyyparsers.read_field_h5(
-                    self.step.sdat.hdf5 / xmff, filestem, self.step.isnap, header
+                    xmff, filestem, self.step.isnap, header
                 )
                 if parsed_data is not None:
                     break
@@ -405,8 +404,9 @@ class _Fields(abc.Mapping):
         if binfiles:
             header = stagyyparsers.field_header(binfiles.pop())
         elif self.step.sdat.hdf5:
-            xmf = self.step.sdat.hdf5 / "Data.xmf"
-            header = stagyyparsers.read_geom_h5(xmf, self.step.isnap)[0]
+            header = stagyyparsers.read_geom_h5(
+                self.step.sdat._dataxmf, self.step.isnap
+            )[0]
         return header if header else None
 
     @cached_property

--- a/stagpy/stagyydata.py
+++ b/stagpy/stagyydata.py
@@ -22,7 +22,7 @@ import numpy as np
 from . import _helpers, _step, conf, error, parfile, phyvars, stagyyparsers
 from ._step import Step
 from .datatypes import Rprof, Tseries, Vart
-from .stagyyparsers import FieldXmf
+from .stagyyparsers import FieldXmf, TracersXmf
 
 if typing.TYPE_CHECKING:
     from os import PathLike
@@ -814,6 +814,13 @@ class StagyyData:
         assert self.hdf5 is not None
         return FieldXmf(
             path=self.hdf5 / "DataBottom.xmf",
+        )
+
+    @cached_property
+    def _traxmf(self) -> TracersXmf:
+        assert self.hdf5 is not None
+        return TracersXmf(
+            path=self.hdf5 / "DataTracers.xmf",
         )
 
     @property

--- a/stagpy/stagyydata.py
+++ b/stagpy/stagyydata.py
@@ -22,6 +22,7 @@ import numpy as np
 from . import _helpers, _step, conf, error, parfile, phyvars, stagyyparsers
 from ._step import Step
 from .datatypes import Rprof, Tseries, Vart
+from .stagyyparsers import FieldXmf
 
 if typing.TYPE_CHECKING:
     from os import PathLike
@@ -793,6 +794,27 @@ class StagyyData:
         """Path of output hdf5 folder if relevant, None otherwise."""
         h5_folder = self.path / self.par["ioin"]["hdf5_output_folder"]
         return h5_folder if (h5_folder / "Data.xmf").is_file() else None
+
+    @cached_property
+    def _dataxmf(self) -> FieldXmf:
+        assert self.hdf5 is not None
+        return FieldXmf(
+            path=self.hdf5 / "Data.xmf",
+        )
+
+    @cached_property
+    def _topxmf(self) -> FieldXmf:
+        assert self.hdf5 is not None
+        return FieldXmf(
+            path=self.hdf5 / "DataSurface.xmf",
+        )
+
+    @cached_property
+    def _botxmf(self) -> FieldXmf:
+        assert self.hdf5 is not None
+        return FieldXmf(
+            path=self.hdf5 / "DataBottom.xmf",
+        )
 
     @property
     def par(self) -> Namelist:

--- a/stagpy/stagyyparsers.py
+++ b/stagpy/stagyyparsers.py
@@ -36,15 +36,12 @@ if typing.TYPE_CHECKING:
         Mapping,
         Optional,
         Tuple,
-        TypeVar,
     )
     from xml.etree.ElementTree import Element
 
     from numpy import ndarray
     from numpy.typing import NDArray
     from pandas import DataFrame
-
-    T = TypeVar("T")
 
 
 def _tidy_names(
@@ -836,21 +833,6 @@ class XmfEntry:
 @dataclass(frozen=True)
 class FieldXmf:
     path: Path
-
-    def _maybe_get(
-        self,
-        elt: Element,
-        item: str,
-        info: str,
-        conversion: Callable[[str], T],
-    ) -> Optional[T]:
-        """Extract and convert info if item is present."""
-        maybe_item = elt.find(item)
-        if maybe_item is not None:
-            maybe_info = maybe_item.get(info)
-            if maybe_info is not None:
-                return conversion(maybe_info)
-        return None
 
     @cached_property
     def _data(self) -> Mapping[int, XmfEntry]:

--- a/stagpy/stagyyparsers.py
+++ b/stagpy/stagyyparsers.py
@@ -860,13 +860,13 @@ class FieldXmf:
     path: Path
 
     @cached_property
-    def root(self) -> Element:
+    def _root(self) -> Element:
         return xmlET.parse(str(self.path)).getroot()
 
     def get_snap(self, isnap: int) -> Element:
         # Domain, Temporal Collection, Snapshot
         # should check that this is indeed the required snapshot
-        elt_snap = self.root[0][0][isnap]
+        elt_snap = self._root[0][0][isnap]
         if elt_snap is None:
             raise ParsingError(self.path, f"Snapshot {isnap} not present")
         return elt_snap

--- a/stagpy/stagyyparsers.py
+++ b/stagpy/stagyyparsers.py
@@ -847,7 +847,9 @@ class FieldXmf:
                 extra[xs.current.tag] = float(xs.current.attrib["Value"])
                 xs.advance()
 
-            yin_yang = False
+            mesh_name = xs.current.attrib["Name"]
+            yin_yang = mesh_name.startswith("meshYin")
+            i0_yin = int(mesh_name[-5:]) - 1
             twod = None
 
             xs.skip_to_tag("Geometry")
@@ -875,7 +877,6 @@ class FieldXmf:
                     data_text = _try_text(xs.filepath, elt_data)
                     h5file, group = data_text.strip().split(":/", 1)
                     isnap = int(group[-5:])
-                    i0_yin = int(group[-11:-6]) - 1
                     ifile = int(h5file[-14:-9])
                     fields_info[name] = (ifile, shape)
 
@@ -887,7 +888,6 @@ class FieldXmf:
                     break
                 if (name := xs.current.attrib["Name"]).startswith("meshYang"):
                     if i1_yang == 0:
-                        yin_yang = True
                         i0_yang = int(name[-5:]) - 1
                         i1_yang = i0_yang + (i1_yin - i0_yin)
                 else:

--- a/stagpy/stagyyparsers.py
+++ b/stagpy/stagyyparsers.py
@@ -932,14 +932,6 @@ class FieldXmf:
         except KeyError:
             raise ParsingError(self.path, f"no data for snapshot {isnap}")
 
-    def get_snap(self, isnap: int) -> Element:
-        # Domain, Temporal Collection, Snapshot
-        # should check that this is indeed the required snapshot
-        elt_snap = self._root[0][0][isnap]
-        if elt_snap is None:
-            raise ParsingError(self.path, f"Snapshot {isnap} not present")
-        return elt_snap
-
 
 def read_geom_h5(xdmf: FieldXmf, snapshot: int) -> dict[str, Any]:
     """Extract geometry information from hdf5 files.

--- a/stagpy/stagyyparsers.py
+++ b/stagpy/stagyyparsers.py
@@ -836,10 +836,6 @@ class XmfEntry:
 class FieldXmf:
     path: Path
 
-    @cached_property
-    def _root(self) -> Element:
-        return xmlET.parse(str(self.path)).getroot()
-
     def _maybe_get(
         self,
         elt: Element,
@@ -859,7 +855,8 @@ class FieldXmf:
     def _data(self) -> Mapping[int, XmfEntry]:
         # Geometry stuff from surface field is not useful
         data = {}
-        for snap in self._root[0][0]:
+        root = xmlET.parse(str(self.path)).getroot()
+        for snap in root[0][0]:
             time = self._maybe_get(snap, "Time", "Value", float)
             mo_lambda = self._maybe_get(snap, "mo_lambda", "Value", float)
             mo_thick_sol = self._maybe_get(snap, "mo_thick_sol", "Value", float)

--- a/stagpy/stagyyparsers.py
+++ b/stagpy/stagyyparsers.py
@@ -864,19 +864,19 @@ class FieldXmf:
         return xmlET.parse(str(self.path)).getroot()
 
 
-def read_geom_h5(xdmf: FieldXmf, snapshot: int) -> Tuple[Dict[str, Any], Element]:
+def read_geom_h5(xdmf: FieldXmf, snapshot: int) -> dict[str, Any]:
     """Extract geometry information from hdf5 files.
 
     Args:
         xdmf_file: path of the xdmf file.
         snapshot: snapshot number.
     Returns:
-        geometry information and root of xdmf document.
+        geometry information.
     """
     header: Dict[str, Any] = {}
     xdmf_root = xdmf.root
     if snapshot is None:
-        return {}, xdmf_root
+        return {}
 
     # Domain, Temporal Collection, Snapshot
     # should check that this is indeed the required snapshot
@@ -907,7 +907,7 @@ def read_geom_h5(xdmf: FieldXmf, snapshot: int) -> Tuple[Dict[str, Any], Element
         coord_shape.append(_get_dim(xdmf.path, data_item))
         coord_h5.append(xdmf.path.parent / data_text.strip().split(":/", 1)[0])
     _read_coord_h5(coord_h5, coord_shape, header, twod)
-    return header, xdmf_root
+    return header
 
 
 def _to_spherical(flds: ndarray, header: Dict[str, Any]) -> ndarray:
@@ -978,9 +978,8 @@ def read_field_h5(
         unavailable.
     """
     if header is None:
-        header, xdmf_root = read_geom_h5(xdmf, snapshot)
-    else:
-        xdmf_root = xdmf.root
+        header = read_geom_h5(xdmf, snapshot)
+    xdmf_root = xdmf.root
 
     npc = header["nts"] // header["ncs"]  # number of grid point per node
     flds = np.zeros(_flds_shape(fieldname, header))

--- a/stagpy/stagyyparsers.py
+++ b/stagpy/stagyyparsers.py
@@ -875,8 +875,6 @@ def read_geom_h5(xdmf: FieldXmf, snapshot: int) -> dict[str, Any]:
     """
     header: Dict[str, Any] = {}
     xdmf_root = xdmf.root
-    if snapshot is None:
-        return {}
 
     # Domain, Temporal Collection, Snapshot
     # should check that this is indeed the required snapshot

--- a/stagpy/stagyyparsers.py
+++ b/stagpy/stagyyparsers.py
@@ -675,7 +675,7 @@ def _ncores(meshes: List[Dict[str, ndarray]], twod: Optional[str]) -> ndarray:
         ):
             nns[0] += 1
             nnpb -= 1
-    cpu = lambda icy: icy * nns[0]
+    cpu = lambda icy: icy * nns[0]  # noqa: E731
     if twod is None or "Y" in twod:
         while (
             nnpb > 1
@@ -684,7 +684,7 @@ def _ncores(meshes: List[Dict[str, ndarray]], twod: Optional[str]) -> ndarray:
         ):
             nns[1] += 1
             nnpb -= nns[0]
-    cpu = lambda icz: icz * nns[0] * nns[1]
+    cpu = lambda icz: icz * nns[0] * nns[1]  # noqa: E731
     while (
         nnpb > 1
         and meshes[cpu(nns[2])]["Z"][0, 0, 0] == meshes[cpu(nns[2] - 1)]["Z"][0, 0, -1]

--- a/stagpy/xdmf.py
+++ b/stagpy/xdmf.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from functools import cached_property
+from pathlib import Path
+from typing import Iterator
+from xml.etree import ElementTree as ET
+
+
+class XmlStream:
+    def __init__(self, filepath: Path):
+        self.filepath = filepath
+        self._event = "end"
+        self._elem: ET.Element
+
+    @cached_property
+    def _cursor(self) -> Iterator[tuple[str, ET.Element]]:
+        return ET.iterparse(str(self.filepath), events=("start", "end"))
+
+    def _to_next_start(self) -> ET.Element:
+        for self._event, self._elem in self._cursor:
+            if self._event == "start":
+                return self._elem
+            self._elem.clear()
+        raise RuntimeError("Reached end of file")
+
+    @property
+    def current(self) -> ET.Element:
+        """Element at "start" event."""
+        if self._event == "start":
+            return self._elem
+        return self._to_next_start()
+
+    def advance(self) -> None:
+        """Advance to next "start" event."""
+        self.current  # make sure to be at current "start" event
+        self._to_next_start()
+
+    def skip_to_tag(self, tag: str) -> None:
+        """Progress in file (both width and depth) until reaching the given tag."""
+        while self.current.tag != tag:
+            self.advance()
+
+    def iter_tag(self, tag: str) -> Iterator[None]:
+        try:
+            while True:
+                self.skip_to_tag(tag)
+                yield None
+        except RuntimeError:
+            pass
+
+    def drop(self) -> None:
+        """Discard the current element and its children."""
+        self.current  # make sure to be at current "start" event
+        for self._event, elem in self._cursor:
+            if self._event == "start":
+                self.drop()
+            else:
+                elem.clear()
+                return
+
+    @contextmanager
+    def load(self) -> Iterator[ET.Element]:
+        """Fully read the current element and its children."""
+        self.current  # make sure to be at current "start" event
+        for self._event, elem in self._cursor:
+            if self._event == "start":
+                self.load().__enter__()
+            else:
+                yield elem
+                break
+        elem.clear()


### PR DESCRIPTION
Thanks to @robsidian for bringing this issue to my attention!

When reading HDF5 output, determining output files and datasets names for a given snapshot is done by parsing `Data.xmf` (and similar for surface fields and tracer data). This file was parsed and the XML tree fully built in memory _every time_ a field was queried, leading to poor performances both in time and space.

This PR uses a new strategy to parse those xml files: they are parsed only once per `StagyyData` instance, caching useful information, and never building the full XML tree in memory. The time needed to parse the XML file with the new strategy is roughly the same as the time previously needed to parse it, so as soon as more than exactly one field on one snapshot is queried, performances are improved. This also dramatically reduces the memory footprint since the XML tree is no longer fully built in memory (now negligible compared to the memory typically needed to load fields in memory).