### PR TITLE
remove global `Config` instance and `scaling.dimensional`

### DIFF
--- a/Examples/annulus/par
+++ b/Examples/annulus/par
@@ -1,4 +1,5 @@
 &switches
+    dimensional_units = .false.
 /
 
 &geometry

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ from pkg_resources import get_distribution
 
 sys.path.insert(0, os.path.abspath(".."))
 
-import stagpy
+from stagpy.config import Config
 
 html_theme = "sphinx_rtd_theme"
 
@@ -93,7 +93,8 @@ with dfile.open("w") as fid:
         """
         )
     )
-    for sec_fld in fields(stagpy.conf):
+    stagpy_conf = Config.default_()
+    for sec_fld in fields(stagpy_conf):
         sec_name = sec_fld.name
         fid.write(
             dedent(
@@ -107,7 +108,7 @@ with dfile.open("w") as fid:
             """.format(sec_name)
             )
         )
-        section = getattr(stagpy.conf, sec_name)
+        section = getattr(stagpy_conf, sec_name)
         for fld in fields(section):
             opt = fld.name
             entry = section.meta_(opt).entry

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ Welcome to StagPy's documentation!
    sources/apiref/commands
    sources/apiref/config
    sources/apiref/datatypes
+   sources/apiref/dimensions
    sources/apiref/error
    sources/apiref/field
    sources/apiref/parfile

--- a/docs/sources/apiref/dimensions.rst
+++ b/docs/sources/apiref/dimensions.rst
@@ -1,0 +1,5 @@
+dimensions
+==========
+
+.. automodule:: stagpy.dimensions
+   :members:

--- a/docs/sources/apiref/phyvars.rst
+++ b/docs/sources/apiref/phyvars.rst
@@ -56,4 +56,4 @@ phyvars
 
       Dictionary mapping dimension strings (**dim** fields in ``Var*``) to
       functions which are themselves mapping from
-      :class:`~stagpy.stagyydata.StagyyData` to the scale for that dimension.
+      :class:`~stagpy.dimensions.Scales` to the scale for that dimension.

--- a/docs/sources/apiref/stagpy.rst
+++ b/docs/sources/apiref/stagpy.rst
@@ -12,8 +12,3 @@ stagpy
       commits since the last stable version and the last commit hash. If you
       made modifications to the code that are not committed yet, the date of
       the last modification appears in the ``'.dYYYYMMDD'`` segment.
-
-   .. data:: conf
-
-      Global :class:`loam.manager.ConfigurationManager` instance, holding
-      configuration options.

--- a/docs/sources/apiref/stagyydata.rst
+++ b/docs/sources/apiref/stagyydata.rst
@@ -2,5 +2,5 @@ stagyydata
 =============
 
 .. automodule:: stagpy.stagyydata
-   :members: _Scales, _Refstate, _Tseries, _RprofsAveraged, _Steps, _Snaps,
-             _StepsView, StagyyData
+   :members: StagyyData
+   :private-members: _Refstate, _Tseries, _RprofsAveraged, _Steps, _Snaps, _StepsView

--- a/stagpy/__init__.py
+++ b/stagpy/__init__.py
@@ -20,8 +20,6 @@ import signal
 import sys
 import typing
 
-from . import config
-
 if typing.TYPE_CHECKING:
     from typing import Any, NoReturn
 
@@ -59,10 +57,6 @@ try:
     from ._version import version as __version__
 except ImportError:
     __version__ = "unknown"
-
-conf = config.Config.default_()
-if config.CONFIG_LOCAL.is_file():
-    conf.update_from_file_(config.CONFIG_LOCAL)
 
 if not DEBUG:
     signal.signal(signal.SIGINT, _PREV_INT)

--- a/stagpy/__init__.py
+++ b/stagpy/__init__.py
@@ -9,44 +9,7 @@ encountered StagpyErrors is printed. Set the environment variable STAGPY_DEBUG
 to issue warnings normally and raise StagpyError.
 """
 
-from __future__ import annotations
-
-import os
-import signal
-import sys
-import typing
-
-if typing.TYPE_CHECKING:
-    from typing import Any, NoReturn
-
-
-DEBUG = os.getenv("STAGPY_DEBUG") is not None
-
-
-def sigint_handler(*_: Any) -> NoReturn:
-    """Handler of SIGINT signal.
-
-    It is set when you use StagPy as a command line tool to handle gracefully
-    keyboard interruption.
-    """
-    print("\nSo long, and thanks for all the fish.")
-    sys.exit()
-
-
-if DEBUG:
-    print(
-        "StagPy runs in DEBUG mode because the environment variable",
-        'STAGPY_DEBUG is set to "True"',
-        sep="\n",
-        end="\n\n",
-    )
-else:
-    _PREV_INT = signal.signal(signal.SIGINT, sigint_handler)
-
 try:
     from ._version import version as __version__
 except ImportError:
     __version__ = "unknown"
-
-if not DEBUG:
-    signal.signal(signal.SIGINT, _PREV_INT)

--- a/stagpy/__init__.py
+++ b/stagpy/__init__.py
@@ -4,13 +4,9 @@ StagPy is both a CLI tool and a powerful Python library. See the
 documentation at
 https://stagpy.readthedocs.io/en/stable/
 
-When using the CLI interface, if the environment variable STAGPY_DEBUG is set
-to a truthy value, warnings are issued normally and StagpyError are raised.
-Otherwise, warnings are ignored and only a short form of encountered
-StagpyErrors is printed.
-
-Truthy values for environment variables are 'true', 't', 'yes', 'y', 'on', '1',
-and uppercase versions of those.
+When using the CLI interface, warnings are ignored and only a short form of
+encountered StagpyErrors is printed. Set the environment variable STAGPY_DEBUG
+to issue warnings normally and raise StagpyError.
 """
 
 from __future__ import annotations
@@ -24,13 +20,7 @@ if typing.TYPE_CHECKING:
     from typing import Any, NoReturn
 
 
-def _env(var: str) -> bool:
-    """Return whether var is set to True."""
-    val = os.getenv(var, default="").lower()
-    return val in ("true", "t", "yes", "y", "on", "1")
-
-
-DEBUG = _env("STAGPY_DEBUG")
+DEBUG = os.getenv("STAGPY_DEBUG") is not None
 
 
 def sigint_handler(*_: Any) -> NoReturn:

--- a/stagpy/__main__.py
+++ b/stagpy/__main__.py
@@ -12,7 +12,11 @@ def main() -> None:
     if not DEBUG:
         signal.signal(signal.SIGINT, sigint_handler)
         warnings.simplefilter("ignore")
-    from . import args, conf, error
+    from . import args, config, error
+
+    conf = config.Config.default_()
+    if config.CONFIG_LOCAL.is_file():
+        conf.update_from_file_(config.CONFIG_LOCAL)
 
     try:
         args.parse_args(conf)(conf)

--- a/stagpy/__main__.py
+++ b/stagpy/__main__.py
@@ -12,10 +12,10 @@ def main() -> None:
     if not DEBUG:
         signal.signal(signal.SIGINT, sigint_handler)
         warnings.simplefilter("ignore")
-    from . import args, error
+    from . import args, conf, error
 
     try:
-        args.parse_args()()
+        args.parse_args(conf)(conf)
     except error.StagpyError as err:
         if DEBUG:
             raise

--- a/stagpy/__main__.py
+++ b/stagpy/__main__.py
@@ -1,17 +1,36 @@
 """The stagpy module is callable."""
 
+from __future__ import annotations
+
+import os
 import signal
 import sys
 import warnings
+from typing import Any, NoReturn
 
-from . import DEBUG, sigint_handler
+
+def sigint_handler(*_: Any) -> NoReturn:
+    """Handler of SIGINT signal.
+
+    It is set when you use StagPy as a command line tool to handle gracefully
+    keyboard interruption.
+    """
+    print("\nSo long, and thanks for all the fish.")
+    sys.exit()
 
 
 def main() -> None:
     """Implement StagPy entry point."""
-    if not DEBUG:
+    debug = os.getenv("STAGPY_DEBUG") is not None
+    if debug:
+        print(
+            "env variable 'STAGPY_DEBUG' is set: StagPy runs in DEBUG mode",
+            end="\n\n",
+        )
+    else:
         signal.signal(signal.SIGINT, sigint_handler)
         warnings.simplefilter("ignore")
+
     from . import args, config, error
 
     conf = config.Config.default_()
@@ -21,7 +40,7 @@ def main() -> None:
     try:
         args.parse_args(conf)(conf)
     except error.StagpyError as err:
-        if DEBUG:
+        if debug:
             raise
         errtype = type(err).__name__
         print(

--- a/stagpy/_helpers.py
+++ b/stagpy/_helpers.py
@@ -15,6 +15,21 @@ if typing.TYPE_CHECKING:
     from matplotlib.figure import Figure
     from numpy import ndarray
 
+    from .config import Config
+    from .stagyydata import StagyyData, _StepsView
+
+
+def walk(sdat: StagyyData, conf: Config) -> _StepsView:
+    """Return view on configured steps slice.
+
+    Other Parameters:
+        conf.core.snapshots: the slice of snapshots.
+        conf.core.timesteps: the slice of timesteps.
+    """
+    if conf.core.timesteps:
+        return sdat.steps[conf.core.timesteps]
+    return sdat.snaps[conf.core.snapshots]
+
 
 def out_name(stem: str, timestep: Optional[int] = None) -> str:
     """Return StagPy out file name.

--- a/stagpy/_helpers.py
+++ b/stagpy/_helpers.py
@@ -69,7 +69,10 @@ def scilabel(value: float, precision: int = 2) -> str:
 
 
 def saveplot(
-    fig: Figure, *name_args: Any, close: bool = True, **name_kwargs: Any
+    fig: Figure,
+    stem: str,
+    timestep: Optional[int] = None,
+    close: bool = True,
 ) -> None:
     """Save matplotlib figure.
 
@@ -78,11 +81,11 @@ def saveplot(
 
     Args:
         fig: the :class:`matplotlib.figure.Figure` to save.
+        stem: short description of file content.
+        timestep: timestep if relevant.
         close: whether to close the figure.
-        name_args: positional arguments passed on to :func:`out_name`.
-        name_kwargs: keyword arguments passed on to :func:`out_name`.
     """
-    oname = out_name(*name_args, **name_kwargs)
+    oname = out_name(stem, timestep)
     fig.savefig(
         f"{oname}.{conf.plot.format}", format=conf.plot.format, bbox_inches="tight"
     )

--- a/stagpy/_helpers.py
+++ b/stagpy/_helpers.py
@@ -18,12 +18,7 @@ if typing.TYPE_CHECKING:
 
 
 def walk(sdat: StagyyData, conf: Config) -> _StepsView:
-    """Return view on configured steps slice.
-
-    Other Parameters:
-        conf.core.snapshots: the slice of snapshots.
-        conf.core.timesteps: the slice of timesteps.
-    """
+    """Return view on configured steps slice."""
     if conf.core.timesteps:
         return sdat.steps[conf.core.timesteps]
     return sdat.snaps[conf.core.snapshots]

--- a/stagpy/_helpers.py
+++ b/stagpy/_helpers.py
@@ -7,8 +7,6 @@ from inspect import getdoc
 
 import matplotlib.pyplot as plt
 
-from . import conf
-
 if typing.TYPE_CHECKING:
     from typing import Any, Optional
 
@@ -31,7 +29,7 @@ def walk(sdat: StagyyData, conf: Config) -> _StepsView:
     return sdat.snaps[conf.core.snapshots]
 
 
-def out_name(stem: str, timestep: Optional[int] = None) -> str:
+def out_name(conf: Config, stem: str, timestep: Optional[int] = None) -> str:
     """Return StagPy out file name.
 
     Args:
@@ -40,9 +38,6 @@ def out_name(stem: str, timestep: Optional[int] = None) -> str:
 
     Returns:
         the output file name.
-
-    Other Parameters:
-        conf.core.outname: the generic name stem, defaults to ``'stagpy'``.
     """
     if conf.core.shortname:
         return conf.core.outname
@@ -69,6 +64,7 @@ def scilabel(value: float, precision: int = 2) -> str:
 
 
 def saveplot(
+    conf: Config,
     fig: Figure,
     stem: str,
     timestep: Optional[int] = None,
@@ -85,7 +81,7 @@ def saveplot(
         timestep: timestep if relevant.
         close: whether to close the figure.
     """
-    oname = out_name(stem, timestep)
+    oname = out_name(conf, stem, timestep)
     fig.savefig(
         f"{oname}.{conf.plot.format}", format=conf.plot.format, bbox_inches="tight"
     )

--- a/stagpy/_step.py
+++ b/stagpy/_step.py
@@ -471,8 +471,7 @@ class _Rprofs:
 
     :class:`_Rprofs` implements the getitem mechanism.  Keys are profile names
     defined in :data:`stagpy.phyvars.RPROF[_EXTRA]`.  Items are
-    :class:`stagpy.datatypes.Rprof` instances.  Note that
-    profiles are automatically scaled if conf.scaling.dimensional is True.
+    :class:`stagpy.datatypes.Rprof` instances.
 
     Attributes:
         step: the :class:`Step` owning the :class:`_Rprofs` instance
@@ -518,8 +517,6 @@ class _Rprofs:
             meta = rpf.meta
         else:
             raise error.UnknownRprofVarError(name)
-        rprof, _ = step.sdat.scale(rprof, meta.dim)
-        rad, _ = step.sdat.scale(rad, "m")
 
         return Rprof(rprof, rad, meta)
 

--- a/stagpy/_step.py
+++ b/stagpy/_step.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from . import error, phyvars, stagyyparsers
 from .datatypes import Field, Rprof, Varr
+from .dimensions import Scales
 
 if typing.TYPE_CHECKING:
     from typing import (
@@ -560,7 +561,7 @@ class _Rprofs:
                 rcmb = 0
         rbot = max(rcmb, 0)
         thickness = (
-            step.sdat.scales.length
+            Scales(step.sdat).length
             if step.sdat.par.get("switches", "dimensional_units", True)
             else 1
         )

--- a/stagpy/args.py
+++ b/stagpy/args.py
@@ -109,7 +109,7 @@ def parse_args(arglist: Optional[List[str]] = None) -> Callable[[], None]:
         return cmd_args.func
 
     if conf.common.config:
-        commands.config_pp(climan.sections_list(sub_cmd))
+        commands.config_pp(climan.sections_list(sub_cmd), conf)
 
     _load_mplstyle()
 

--- a/stagpy/args.py
+++ b/stagpy/args.py
@@ -16,7 +16,6 @@ from . import __doc__ as doc_module
 from . import (
     _styles,
     commands,
-    conf,
     field,
     plates,
     refstate,
@@ -24,6 +23,7 @@ from . import (
     time_series,
 )
 from ._helpers import baredoc
+from .config import Config
 
 if typing.TYPE_CHECKING:
     from typing import Any, Callable, List, Optional
@@ -35,13 +35,13 @@ def _sub(cmd: Any, *sections: str) -> Subcmd:
     return Subcmd(baredoc(cmd), *sections, func=cmd_func)
 
 
-def _bare_cmd() -> None:
+def _bare_cmd(conf: Config) -> None:
     """Print help message when no arguments are given."""
     print(doc_module)
     print("Run `stagpy -h` for usage")
 
 
-def _load_mplstyle() -> None:
+def _load_mplstyle(conf: Config) -> None:
     """Try to load conf.plot.mplstyle matplotlib style."""
     for style in conf.plot.mplstyle:
         style_fname = style + ".mplstyle"
@@ -71,10 +71,10 @@ SUB_CMDS = MappingProxyType(
 )
 
 
-def parse_args(arglist: Optional[List[str]] = None) -> Callable[[], None]:
+def parse_args(
+    conf: Config, arglist: Optional[List[str]] = None
+) -> Callable[[Config], None]:
     """Parse cmd line arguments.
-
-    Update :attr:`stagpy.conf` accordingly.
 
     Args:
         arglist: the list of cmd line arguments. If set to None, the arguments
@@ -84,7 +84,7 @@ def parse_args(arglist: Optional[List[str]] = None) -> Callable[[], None]:
         the function implementing the sub command to be executed.
     """
 
-    def compl_cmd() -> None:
+    def compl_cmd(conf: Config) -> None:
         if conf.completions.zsh:
             filepath = Path("_stagpy.sh")
             print(f"writing zsh completion file {filepath}")
@@ -111,6 +111,6 @@ def parse_args(arglist: Optional[List[str]] = None) -> Callable[[], None]:
     if conf.common.config:
         commands.config_pp(climan.sections_list(sub_cmd), conf)
 
-    _load_mplstyle()
+    _load_mplstyle(conf)
 
     return cmd_args.func

--- a/stagpy/args.py
+++ b/stagpy/args.py
@@ -1,4 +1,4 @@
-"""Parse command line arguments and update :attr:`stagpy.conf`."""
+"""Parse command line arguments."""
 
 from __future__ import annotations
 

--- a/stagpy/commands.py
+++ b/stagpy/commands.py
@@ -11,9 +11,9 @@ from textwrap import TextWrapper, indent
 
 import pandas
 
-from . import __version__, conf, phyvars, stagyydata
+from . import __version__, phyvars, stagyydata
 from ._helpers import baredoc
-from .config import CONFIG_LOCAL
+from .config import CONFIG_LOCAL, Config
 
 if typing.TYPE_CHECKING:
     from typing import Callable, Iterable, Mapping, Optional, Sequence, Tuple, Union
@@ -29,6 +29,8 @@ def info_cmd() -> None:
     Other Parameters:
         conf.info
     """
+    from . import conf
+
     sdat = stagyydata.StagyyData(conf.core.path)
     lsnap = sdat.snaps[-1]
     lstep = sdat.steps[-1]
@@ -138,6 +140,8 @@ def var_cmd() -> None:
     See :mod:`stagpy.phyvars` where the lists of variables organized by command
     are defined.
     """
+    from . import conf
+
     print_all = not any(getattr(conf.var, fld.name) for fld in fields(conf.var))
     if print_all or conf.var.field:
         print("field:")
@@ -169,7 +173,7 @@ def version_cmd() -> None:
     print(f"stagpy version: {__version__}")
 
 
-def config_pp(subs: Iterable[str]) -> None:
+def config_pp(subs: Iterable[str], conf: Config) -> None:
     """Pretty print of configuration options.
 
     Args:
@@ -199,7 +203,9 @@ def config_cmd() -> None:
     Other Parameters:
         conf.config
     """
+    from . import conf
+
     if conf.config.create:
         conf.default_().to_file_(CONFIG_LOCAL)
     else:
-        config_pp(sec.name for sec in fields(conf))
+        config_pp((sec.name for sec in fields(conf)), conf)

--- a/stagpy/commands.py
+++ b/stagpy/commands.py
@@ -10,7 +10,7 @@ from shutil import get_terminal_size
 from textwrap import TextWrapper, indent
 
 from . import __version__, phyvars, stagyydata
-from ._helpers import baredoc
+from ._helpers import baredoc, walk
 from .config import CONFIG_LOCAL, Config
 
 if typing.TYPE_CHECKING:
@@ -46,7 +46,7 @@ def info_cmd() -> None:
     else:
         print("Spherical", dimension)
     print()
-    for step in sdat.walk:
+    for step in walk(sdat, conf):
         print(f"Step {step.istep}/{lstep.istep}", end="")
         if step.isnap is not None:
             print(f", snapshot {step.isnap}/{lsnap.isnap}")

--- a/stagpy/commands.py
+++ b/stagpy/commands.py
@@ -22,11 +22,7 @@ if typing.TYPE_CHECKING:
 
 
 def info_cmd(conf: Config) -> None:
-    """Print basic information about StagYY run.
-
-    Other Parameters:
-        conf.info
-    """
+    """Print basic information about StagYY run."""
     sdat = stagyydata.StagyyData(conf.core.path)
     lsnap = sdat.snaps[-1]
     lstep = sdat.steps[-1]
@@ -174,11 +170,7 @@ def config_pp(subs: Iterable[str], conf: Config) -> None:
 
 
 def config_cmd(conf: Config) -> None:
-    """Configuration handling.
-
-    Other Parameters:
-        conf.config
-    """
+    """Configuration handling."""
     if conf.config.create:
         conf.default_().to_file_(CONFIG_LOCAL)
     else:

--- a/stagpy/commands.py
+++ b/stagpy/commands.py
@@ -9,8 +9,6 @@ from math import ceil
 from shutil import get_terminal_size
 from textwrap import TextWrapper, indent
 
-import pandas
-
 from . import __version__, phyvars, stagyydata
 from ._helpers import baredoc
 from .config import CONFIG_LOCAL, Config
@@ -55,24 +53,6 @@ def info_cmd() -> None:
         else:
             print()
         series = step.timeinfo.loc[list(conf.info.output)]
-        if conf.scaling.dimensional:
-            series = series.copy()
-            dimensions = []
-            for var, val in series.iteritems():
-                meta = phyvars.TIME.get(var)
-                dim = meta.dim if meta is not None else "1"
-                if dim == "1":
-                    dimensions.append("")
-                else:
-                    series[var], dim = sdat.scale(val, dim)
-                    dimensions.append(dim)
-            series = pandas.concat(
-                [
-                    series,
-                    pandas.Series(data=dimensions, index=series.index, name="dim"),
-                ],
-                axis=1,
-            )  # type: ignore
         print(indent(series.to_string(header=False), "  "))
         print()
 

--- a/stagpy/commands.py
+++ b/stagpy/commands.py
@@ -21,14 +21,12 @@ if typing.TYPE_CHECKING:
     from .datatypes import Varf, Varr, Vart
 
 
-def info_cmd() -> None:
+def info_cmd(conf: Config) -> None:
     """Print basic information about StagYY run.
 
     Other Parameters:
         conf.info
     """
-    from . import conf
-
     sdat = stagyydata.StagyyData(conf.core.path)
     lsnap = sdat.snaps[-1]
     lstep = sdat.steps[-1]
@@ -114,14 +112,12 @@ def _layout(
     _pretty_print(desc, min_col_width=26)
 
 
-def var_cmd() -> None:
+def var_cmd(conf: Config) -> None:
     """Print a list of available variables.
 
     See :mod:`stagpy.phyvars` where the lists of variables organized by command
     are defined.
     """
-    from . import conf
-
     print_all = not any(getattr(conf.var, fld.name) for fld in fields(conf.var))
     if print_all or conf.var.field:
         print("field:")
@@ -145,7 +141,7 @@ def var_cmd() -> None:
         print()
 
 
-def version_cmd() -> None:
+def version_cmd(conf: Config) -> None:
     """Print StagPy version.
 
     Use :data:`stagpy.__version__` to obtain the version in a script.
@@ -177,14 +173,12 @@ def config_pp(subs: Iterable[str], conf: Config) -> None:
             print()
 
 
-def config_cmd() -> None:
+def config_cmd(conf: Config) -> None:
     """Configuration handling.
 
     Other Parameters:
         conf.config
     """
-    from . import conf
-
     if conf.config.create:
         conf.default_().to_file_(CONFIG_LOCAL)
     else:

--- a/stagpy/config.py
+++ b/stagpy/config.py
@@ -78,7 +78,6 @@ class Scaling(Section):
 
     yearins: float = entry(val=3.154e7, in_cli=False, doc="year in seconds")
     ttransit: float = entry(val=1.78e15, in_cli=False, doc="transit time in My")
-    dimensional: bool = switch_opt(False, None, "use dimensional units")
     time_in_y: bool = switch_opt(True, None, "dimensional time is in year")
     vel_in_cmpy: bool = switch_opt(True, None, "dimensional velocity is in cm/year")
     factors: Dict[str, str] = entry(

--- a/stagpy/datatypes.py
+++ b/stagpy/datatypes.py
@@ -13,8 +13,7 @@ if typing.TYPE_CHECKING:
 class Varf:
     """Metadata of scalar field.
 
-    `dim` is the dimension used to :func:`~stagpy.stagyydata.StagyyData.scale` to
-    dimensional values.
+    `dim` is the dimension used to scale to dimensional values.
     """
 
     description: str
@@ -33,8 +32,7 @@ class Field:
 class Varr:
     """Metadata of radial profiles.
 
-    `dim` is the dimension used to :func:`~stagpy.stagyydata.StagyyData.scale` to
-    dimensional values.
+    `dim` is the dimension used to scale to dimensional values.
     """
 
     description: str
@@ -55,8 +53,7 @@ class Rprof:
 class Vart:
     """Metadata of time series.
 
-    `dim` is the dimension used to :func:`~stagpy.stagyydata.StagyyData.scale` to
-    dimensional values.
+    `dim` is the dimension used to scale to dimensional values.
     """
 
     description: str

--- a/stagpy/dimensions.py
+++ b/stagpy/dimensions.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import typing
+from functools import cached_property
+
+if typing.TYPE_CHECKING:
+    from .parfile import StagyyPar
+    from .stagyydata import StagyyData
+
+
+class Scales:
+    """Dimensional scales.
+
+    Args:
+        sdat: the StagyyData instance owning the :class:`_Scales` instance.
+    """
+
+    def __init__(self, sdat: StagyyData):
+        self._sdat = sdat
+
+    @property
+    def par(self) -> StagyyPar:
+        return self._sdat.par
+
+    @cached_property
+    def length(self) -> float:
+        """Length in m."""
+        thick = self.par.get("geometry", "d_dimensional", 2890e3)
+        if self.par.get("boundaries", "air_layer", False):
+            thick += self.par.nml["boundaries"]["air_thickness"]
+        return thick
+
+    @property
+    def temperature(self) -> float:
+        """Temperature in K."""
+        return self.par.nml["refstate"]["deltaT_dimensional"]
+
+    @property
+    def density(self) -> float:
+        """Density in kg/m3."""
+        return self.par.nml["refstate"]["dens_dimensional"]
+
+    @property
+    def th_cond(self) -> float:
+        """Thermal conductivity in W/(m.K)."""
+        return self.par.nml["refstate"]["tcond_dimensional"]
+
+    @property
+    def sp_heat(self) -> float:
+        """Specific heat capacity in J/(kg.K)."""
+        return self.par.nml["refstate"]["Cp_dimensional"]
+
+    @property
+    def dyn_visc(self) -> float:
+        """Dynamic viscosity in Pa.s."""
+        return self.par.nml["viscosity"]["eta0"]
+
+    @property
+    def th_diff(self) -> float:
+        """Thermal diffusivity in m2/s."""
+        return self.th_cond / (self.density * self.sp_heat)
+
+    @property
+    def time(self) -> float:
+        """Time in s."""
+        return self.length**2 / self.th_diff
+
+    @property
+    def velocity(self) -> float:
+        """Velocity in m/s."""
+        return self.length / self.time
+
+    @property
+    def acceleration(self) -> float:
+        """Acceleration in m/s2."""
+        return self.length / self.time**2
+
+    @property
+    def power(self) -> float:
+        """Power in W."""
+        return self.th_cond * self.temperature * self.length
+
+    @property
+    def heat_flux(self) -> float:
+        """Local heat flux in W/m2."""
+        return self.power / self.length**2
+
+    @property
+    def heat_production(self) -> float:
+        """Local heat production in W/m3."""
+        return self.power / self.length**3
+
+    @property
+    def stress(self) -> float:
+        """Stress in Pa."""
+        return self.dyn_visc / self.time

--- a/stagpy/dimensions.py
+++ b/stagpy/dimensions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+from dataclasses import dataclass
 from functools import cached_property
 
 if typing.TYPE_CHECKING:
@@ -8,19 +9,15 @@ if typing.TYPE_CHECKING:
     from .stagyydata import StagyyData
 
 
+@dataclass(frozen=True)
 class Scales:
-    """Dimensional scales.
+    """Dimensional scales."""
 
-    Args:
-        sdat: the StagyyData instance owning the :class:`_Scales` instance.
-    """
-
-    def __init__(self, sdat: StagyyData):
-        self._sdat = sdat
+    sdat: StagyyData
 
     @property
     def par(self) -> StagyyPar:
-        return self._sdat.par
+        return self.sdat.par
 
     @cached_property
     def length(self) -> float:

--- a/stagpy/field.py
+++ b/stagpy/field.py
@@ -354,15 +354,8 @@ def _findminmax(
     return minmax
 
 
-def cmd() -> None:
-    """Implementation of field subcommand.
-
-    Other Parameters:
-        conf.field
-        conf.core
-    """
-    from . import conf
-
+def cmd(conf: Config) -> None:
+    """Implementation of field subcommand."""
     sdat = StagyyData(conf.core.path)
     view = _helpers.walk(sdat, conf)
     # no more than two fields in a subplot

--- a/stagpy/field.py
+++ b/stagpy/field.py
@@ -27,6 +27,7 @@ if typing.TYPE_CHECKING:
 
     from ._step import Step
     from .datatypes import Varf
+    from .stagyydata import _StepsView
 
 
 # The location is off for vertical velocities: they have an extra
@@ -335,11 +336,11 @@ def plot_vec(
 
 
 def _findminmax(
-    sdat: StagyyData, sovs: Iterable[str]
+    view: _StepsView, sovs: Iterable[str]
 ) -> Dict[str, Tuple[float, float]]:
     """Find min and max values of several fields."""
     minmax: Dict[str, Tuple[float, float]] = {}
-    for step in sdat.walk.filter(snap=True):
+    for step in view.filter(snap=True):
         for var in sovs:
             if var in step.fields:
                 vals = step.fields[var].values
@@ -363,6 +364,7 @@ def cmd() -> None:
     from . import conf
 
     sdat = StagyyData(conf.core.path)
+    view = _helpers.walk(sdat, conf)
     # no more than two fields in a subplot
     lovs = [[slov[:2] for slov in plov] for plov in conf.field.plot]
     minmax = {}
@@ -370,8 +372,8 @@ def cmd() -> None:
         conf.plot.vmin = None
         conf.plot.vmax = None
         sovs = set(slov[0] for plov in lovs for slov in plov)
-        minmax = _findminmax(sdat, sovs)
-    for step in sdat.walk.filter(snap=True):
+        minmax = _findminmax(view, sovs)
+    for step in view.filter(snap=True):
         for vfig in lovs:
             fig, axes = plt.subplots(
                 ncols=len(vfig), squeeze=False, figsize=(6 * len(vfig), 6)

--- a/stagpy/field.py
+++ b/stagpy/field.py
@@ -399,4 +399,4 @@ def cmd() -> None:
                 )
             oname = "_".join(chain.from_iterable(vfig))
             plt.tight_layout(w_pad=3)
-            _helpers.saveplot(fig, oname, step.isnap)
+            _helpers.saveplot(conf, fig, oname, step.isnap)

--- a/stagpy/field.py
+++ b/stagpy/field.py
@@ -180,9 +180,7 @@ def plot_scalar(
         step: a :class:`~stagpy._step.Step` of a StagyyData instance.
         var: the scalar field name.
         field: if not None, it is plotted instead of step.fields[var].  This is
-            useful to plot a masked or rescaled array.  Note that if
-            conf.scaling.dimensional is True, this field will be scaled
-            accordingly.
+            useful to plot a masked or rescaled array.
         axis: the :class:`matplotlib.axes.Axes` object where the field should
             be plotted.  If set to None, a new figure with one subplot is
             created.
@@ -216,8 +214,6 @@ def plot_scalar(
     if conf.field.shift:
         fld = np.roll(fld, conf.field.shift, axis=0)
 
-    fld, unit = step.sdat.scale(fld, meta.dim)
-
     if axis is None:
         fig, axis = plt.subplots(ncols=1)
     else:
@@ -250,11 +246,7 @@ def plot_scalar(
     if conf.field.colorbar:
         cax = make_axes_locatable(axis).append_axes("right", size="3%", pad=0.15)
         cbar = plt.colorbar(surf, cax=cax)
-        cbar.set_label(
-            meta.description
-            + (" pert." if conf.field.perturbation else "")
-            + (f" ({unit})" if unit else "")
-        )
+        cbar.set_label(meta.description + (" pert." if conf.field.perturbation else ""))
     if step.geom.spherical or conf.plot.ratio is None:
         axis.set_aspect("equal")
         axis.set_axis_off()
@@ -283,9 +275,7 @@ def plot_iso(
         step: a :class:`~stagpy._step.Step` of a StagyyData instance.
         var: the scalar field name.
         field: if not None, it is plotted instead of step.fields[var].  This is
-            useful to plot a masked or rescaled array.  Note that if
-            conf.scaling.dimensional is True, this field will be scaled
-            accordingly.
+            useful to plot a masked or rescaled array.
         extra: options that will be passed on to
             :func:`matplotlib.axes.Axes.contour`.
     """
@@ -352,8 +342,7 @@ def _findminmax(
     for step in sdat.walk.filter(snap=True):
         for var in sovs:
             if var in step.fields:
-                field = step.fields[var]
-                vals, _ = sdat.scale(field.values, field.meta.dim)
+                vals = step.fields[var].values
                 if var in minmax:
                     minmax[var] = (
                         min(minmax[var][0], np.nanmin(vals)),
@@ -401,10 +390,10 @@ def cmd() -> None:
                     elif valid_field_var(var[1] + "1"):
                         plot_vec(axis, step, var[1], conf=conf)
             if conf.field.timelabel:
-                time, unit = sdat.scale(step.timeinfo["t"], "s")
+                time = step.timeinfo["t"]
                 time = _helpers.scilabel(time)
                 axes[0, 0].text(
-                    0.02, 1.02, f"$t={time}$ {unit}", transform=axes[0, 0].transAxes
+                    0.02, 1.02, f"$t={time}$", transform=axes[0, 0].transAxes
                 )
             oname = "_".join(chain.from_iterable(vfig))
             plt.tight_layout(w_pad=3)

--- a/stagpy/phyvars.py
+++ b/stagpy/phyvars.py
@@ -19,7 +19,8 @@ if typing.TYPE_CHECKING:
 
     from ._step import Step
     from .datatypes import Field, Rprof, Tseries
-    from .stagyydata import StagyyData, _Scales
+    from .dimensions import Scales
+    from .stagyydata import StagyyData
 
 
 FIELD: Mapping[str, Varf] = MappingProxyType(
@@ -327,7 +328,7 @@ REFSTATE: Mapping[str, Varr] = MappingProxyType(
     }
 )
 
-SCALES: Mapping[str, Callable[[_Scales], float]] = MappingProxyType(
+SCALES: Mapping[str, Callable[[Scales], float]] = MappingProxyType(
     {
         "m": attrgetter("length"),
         "kg/m3": attrgetter("density"),

--- a/stagpy/plates.py
+++ b/stagpy/plates.py
@@ -11,13 +11,14 @@ import numpy as np
 from matplotlib import colors
 from scipy.signal import argrelmax, argrelmin
 
-from . import _helpers, conf, error, field, phyvars
+from . import _helpers, error, field, phyvars
 from ._helpers import saveplot
+from .config import Config
 from .datatypes import Field
 from .stagyydata import StagyyData
 
 if typing.TYPE_CHECKING:
-    from typing import Sequence, TextIO, Tuple, Union
+    from typing import Optional, Sequence, TextIO, Tuple, Union
 
     from matplotlib.axes import Axes
     from numpy import ndarray
@@ -120,7 +121,7 @@ def _annot_pos(
     return p_beg, p_end
 
 
-def _plot_plate_limits_field(axis: Axes, snap: Step) -> None:
+def _plot_plate_limits_field(axis: Axes, snap: Step, conf: Config) -> None:
     """Plot arrows designating ridges and trenches in 2D field plots."""
     itrenches, iridges = detect_plates(snap, conf.plates.vzratio)
     for itrench in itrenches:
@@ -206,7 +207,11 @@ def _continents_location(snap: Step, at_surface: bool = True) -> ndarray:
     return csurf >= 2
 
 
-def plot_at_surface(snap: Step, names: Sequence[Sequence[Sequence[str]]]) -> None:
+def plot_at_surface(
+    snap: Step,
+    names: Sequence[Sequence[Sequence[str]]],
+    conf: Optional[Config],
+) -> None:
     """Plot surface diagnostics.
 
     Args:
@@ -215,6 +220,8 @@ def plot_at_surface(snap: Step, names: Sequence[Sequence[Sequence[str]]]) -> Non
             figures, plots and subplots.  Surface diagnotics can be valid
             surface field names, field names, or `"dv2"` which is d(vphi)/dphi.
     """
+    if conf is None:
+        conf = Config.default_()
     for vfig in names:
         fig, axes = plt.subplots(
             nrows=len(vfig), sharex=True, figsize=(12, 2 * len(vfig))
@@ -258,7 +265,9 @@ def plot_at_surface(snap: Step, names: Sequence[Sequence[Sequence[str]]]) -> Non
         saveplot(fig, fname, snap.isnap)
 
 
-def _write_trench_diagnostics(step: Step, vrms_surf: float, fid: TextIO) -> None:
+def _write_trench_diagnostics(
+    step: Step, vrms_surf: float, fid: TextIO, conf: Config
+) -> None:
     """Print out some trench diagnostics."""
     assert step.isnap is not None
     itrenches, _ = detect_plates(step, conf.plates.vzratio)
@@ -319,7 +328,11 @@ def _write_trench_diagnostics(step: Step, vrms_surf: float, fid: TextIO) -> None
         )
 
 
-def plot_scalar_field(snap: Step, fieldname: str) -> None:
+def plot_scalar_field(
+    snap: Step,
+    fieldname: str,
+    conf: Optional[Config] = None,
+) -> None:
     """Plot scalar field with plate information.
 
     Args:
@@ -327,6 +340,8 @@ def plot_scalar_field(snap: Step, fieldname: str) -> None:
         fieldname: name of the field that should be decorated with plate
             informations.
     """
+    if conf is None:
+        conf = Config.default_()
     fig, axis, _, _ = field.plot_scalar(snap, fieldname)
 
     if conf.plates.continents:
@@ -349,7 +364,7 @@ def plot_scalar_field(snap: Step, fieldname: str) -> None:
     field.plot_vec(axis, snap, "sx" if conf.plates.stress else "v")
 
     # Put arrow where ridges and trenches are
-    _plot_plate_limits_field(axis, snap)
+    _plot_plate_limits_field(axis, snap, conf)
 
     saveplot(fig, f"plates_{fieldname}", snap.isnap, close=conf.plates.zoom is None)
 
@@ -381,6 +396,8 @@ def cmd() -> None:
         conf.plot
         conf.core
     """
+    from . import conf
+
     sdat = StagyyData(conf.core.path)
 
     isurf = _isurf(next(iter(sdat.walk)))
@@ -398,9 +415,9 @@ def cmd() -> None:
 
         for step in sdat.walk.filter(fields=["T"]):
             # could check other fields too
-            _write_trench_diagnostics(step, vrms_surf, fid)
-            plot_at_surface(step, conf.plates.plot)
-            plot_scalar_field(step, conf.plates.field)
+            _write_trench_diagnostics(step, vrms_surf, fid, conf)
+            plot_at_surface(step, conf.plates.plot, conf)
+            plot_scalar_field(step, conf.plates.field, conf)
             if conf.plates.nbplates:
                 time.append(step.timeinfo.loc["t"])
                 itr, ird = detect_plates(step, conf.plates.vzratio)

--- a/stagpy/plates.py
+++ b/stagpy/plates.py
@@ -400,21 +400,22 @@ def cmd() -> None:
     from . import conf
 
     sdat = StagyyData(conf.core.path)
+    view = _helpers.walk(sdat, conf)
 
-    isurf = _isurf(next(iter(sdat.walk)))
-    vrms_surf = sdat.walk.filter(rprofs=True).rprofs_averaged["vhrms"].values[isurf]
+    isurf = _isurf(next(iter(view)))
+    vrms_surf = view.filter(rprofs=True).rprofs_averaged["vhrms"].values[isurf]
     nb_plates = []
     time = []
     istart, iend = None, None
 
-    oname = _helpers.out_name(f"plates_trenches_{sdat.walk.stepstr}")
+    oname = _helpers.out_name(f"plates_trenches_{view.stepstr}")
     with open(f"{oname}.dat", "w") as fid:
         fid.write(
             "#  istep     time   time_My   phi_trench  vel_trench  "
             "distance     phi_cont  age_trench_My\n"
         )
 
-        for step in sdat.walk.filter(fields=["T"]):
+        for step in view.filter(fields=["T"]):
             # could check other fields too
             _write_trench_diagnostics(step, vrms_surf, fid, conf)
             plot_at_surface(step, conf.plates.plot, conf)

--- a/stagpy/plates.py
+++ b/stagpy/plates.py
@@ -342,7 +342,7 @@ def plot_scalar_field(
     """
     if conf is None:
         conf = Config.default_()
-    fig, axis, _, _ = field.plot_scalar(snap, fieldname)
+    fig, axis, _, _ = field.plot_scalar(snap, fieldname, conf=conf)
 
     if conf.plates.continents:
         c_field = np.ma.masked_where(
@@ -356,12 +356,13 @@ def plot_scalar_field(
                 "c",
                 c_field,
                 axis,
+                conf=conf,
                 cmap=cmap,
                 norm=colors.BoundaryNorm([2, 3, 4, 5], cmap.N),
             )
 
     # plotting velocity vectors
-    field.plot_vec(axis, snap, "sx" if conf.plates.stress else "v")
+    field.plot_vec(axis, snap, "sx" if conf.plates.stress else "v", conf=conf)
 
     # Put arrow where ridges and trenches are
     _plot_plate_limits_field(axis, snap, conf)

--- a/stagpy/plates.py
+++ b/stagpy/plates.py
@@ -394,17 +394,8 @@ def plot_scalar_field(
         saveplot(conf, fig, f"plates_zoom_{fieldname}", snap.isnap)
 
 
-def cmd() -> None:
-    """Implementation of plates subcommand.
-
-    Other Parameters:
-        conf.plates
-        conf.scaling
-        conf.plot
-        conf.core
-    """
-    from . import conf
-
+def cmd(conf: Config) -> None:
+    """Implementation of plates subcommand."""
     sdat = StagyyData(conf.core.path)
     view = _helpers.walk(sdat, conf)
 

--- a/stagpy/plates.py
+++ b/stagpy/plates.py
@@ -262,7 +262,7 @@ def plot_at_surface(
                 axis.legend()
         axes[-1].set_xlabel(r"$\phi$")
         axes[-1].set_xlim(snap.geom.p_walls[[0, -1]])
-        saveplot(fig, fname, snap.isnap)
+        saveplot(conf, fig, fname, snap.isnap)
 
 
 def _write_trench_diagnostics(
@@ -367,7 +367,13 @@ def plot_scalar_field(
     # Put arrow where ridges and trenches are
     _plot_plate_limits_field(axis, snap, conf)
 
-    saveplot(fig, f"plates_{fieldname}", snap.isnap, close=conf.plates.zoom is None)
+    saveplot(
+        conf,
+        fig,
+        f"plates_{fieldname}",
+        snap.isnap,
+        close=conf.plates.zoom is None,
+    )
 
     # Zoom
     if conf.plates.zoom is not None:
@@ -385,7 +391,7 @@ def plot_scalar_field(
         yzoom = (snap.geom.rcmb + 1) * np.sin(np.radians(conf.plates.zoom))
         axis.set_xlim(xzoom - ladd, xzoom + radd)
         axis.set_ylim(yzoom - dadd, yzoom + uadd)
-        saveplot(fig, f"plates_zoom_{fieldname}", snap.isnap)
+        saveplot(conf, fig, f"plates_zoom_{fieldname}", snap.isnap)
 
 
 def cmd() -> None:
@@ -408,7 +414,7 @@ def cmd() -> None:
     time = []
     istart, iend = None, None
 
-    oname = _helpers.out_name(f"plates_trenches_{view.stepstr}")
+    oname = _helpers.out_name(conf, f"plates_trenches_{view.stepstr}")
     with open(f"{oname}.dat", "w") as fid:
         fid.write(
             "#  istep     time   time_My   phi_trench  vel_trench  "
@@ -436,11 +442,11 @@ def cmd() -> None:
                 axis.hist(plate_sizes, 10, (0, np.pi))
                 axis.set_ylabel("Number of plates")
                 axis.set_xlabel(r"$\phi$-span")
-                saveplot(fig, "plates_size_distribution", step.isnap)
+                saveplot(conf, fig, "plates_size_distribution", step.isnap)
 
         if conf.plates.nbplates:
             figt, axis = plt.subplots()
             axis.plot(time, nb_plates)
             axis.set_xlabel("Time")
             axis.set_ylabel("Number of plates")
-            saveplot(figt, f"plates_{istart}_{iend}")
+            saveplot(conf, figt, f"plates_{istart}_{iend}")

--- a/stagpy/refstate.py
+++ b/stagpy/refstate.py
@@ -42,15 +42,8 @@ def plot_ref(sdat: StagyyData, var: str, conf: Optional[Config] = None) -> None:
     _helpers.saveplot(conf, fig, f"refstate_{var}")
 
 
-def cmd() -> None:
-    """Implementation of refstate subcommand.
-
-    Other Parameters:
-        conf.core
-        conf.plot
-    """
-    from . import conf
-
+def cmd(conf: Config) -> None:
+    """Implementation of refstate subcommand."""
     sdat = StagyyData(conf.core.path)
 
     for var in conf.refstate.plot:

--- a/stagpy/refstate.py
+++ b/stagpy/refstate.py
@@ -39,7 +39,7 @@ def plot_ref(sdat: StagyyData, var: str, conf: Optional[Config] = None) -> None:
     axis.set_ylabel("z Position")
     if len(adbts) > 2:
         axis.legend()
-    _helpers.saveplot(fig, f"refstate_{var}")
+    _helpers.saveplot(conf, fig, f"refstate_{var}")
 
 
 def cmd() -> None:

--- a/stagpy/refstate.py
+++ b/stagpy/refstate.py
@@ -2,20 +2,25 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 import matplotlib.pyplot as plt
 
-from . import _helpers, conf
+from . import _helpers
+from .config import Config
 from .phyvars import REFSTATE
 from .stagyydata import StagyyData
 
 
-def plot_ref(sdat: StagyyData, var: str) -> None:
+def plot_ref(sdat: StagyyData, var: str, conf: Optional[Config] = None) -> None:
     """Plot one reference state.
 
     Args:
         sdat: a :class:`~stagpy.stagyydata.StagyyData` instance.
         var: refstate variable, a key of :data:`~stagpy.phyvars.REFSTATE`.
     """
+    if conf is None:
+        conf = Config.default_()
     fig, axis = plt.subplots()
     adbts = sdat.refstate.adiabats
     if len(adbts) > 2:
@@ -44,7 +49,9 @@ def cmd() -> None:
         conf.core
         conf.plot
     """
+    from . import conf
+
     sdat = StagyyData(conf.core.path)
 
     for var in conf.refstate.plot:
-        plot_ref(sdat, var)
+        plot_ref(sdat, var, conf)

--- a/stagpy/rprof.py
+++ b/stagpy/rprof.py
@@ -6,16 +6,21 @@ import typing
 
 import matplotlib.pyplot as plt
 
-from . import _helpers, conf
+from . import _helpers
+from .config import Config
 from .stagyydata import StagyyData
 
 if typing.TYPE_CHECKING:
-    from typing import Sequence
+    from typing import Optional, Sequence
 
     from ._step import Step, _Rprofs
 
 
-def plot_rprofs(rprofs: _Rprofs, names: Sequence[Sequence[Sequence[str]]]) -> None:
+def plot_rprofs(
+    rprofs: _Rprofs,
+    names: Sequence[Sequence[Sequence[str]]],
+    conf: Optional[Config] = None,
+) -> None:
     """Plot requested radial profiles.
 
     Args:
@@ -23,6 +28,8 @@ def plot_rprofs(rprofs: _Rprofs, names: Sequence[Sequence[Sequence[str]]]) -> No
             :attr:`_StepsView.rprofs_averaged`.
         names: profile names organized by figures, plots and subplots.
     """
+    if conf is None:
+        conf = Config.default_()
     stepstr = rprofs.stepstr
     sdat = rprofs.step.sdat
 
@@ -97,6 +104,8 @@ def cmd() -> None:
         conf.rprof
         conf.core
     """
+    from . import conf
+
     sdat = StagyyData(conf.core.path)
 
     if conf.rprof.grid:
@@ -104,7 +113,7 @@ def cmd() -> None:
             plot_grid(step)
 
     if conf.rprof.average:
-        plot_rprofs(sdat.walk.rprofs_averaged, conf.rprof.plot)
+        plot_rprofs(sdat.walk.rprofs_averaged, conf.rprof.plot, conf)
     else:
         for step in sdat.walk.filter(rprofs=True):
-            plot_rprofs(step.rprofs, conf.rprof.plot)
+            plot_rprofs(step.rprofs, conf.rprof.plot, conf)

--- a/stagpy/rprof.py
+++ b/stagpy/rprof.py
@@ -66,10 +66,10 @@ def plot_rprofs(
             axes[0].invert_yaxis()
         ylabel = "Depth" if conf.rprof.depth else "Radius"
         axes[0].set_ylabel(ylabel)
-        _helpers.saveplot(fig, fname + stepstr)
+        _helpers.saveplot(conf, fig, fname + stepstr)
 
 
-def plot_grid(step: Step) -> None:
+def plot_grid(step: Step, conf: Optional[Config] = None) -> None:
     """Plot cell position and thickness.
 
     The figure is call grid_N.pdf where N is replace by the step index.
@@ -78,6 +78,8 @@ def plot_grid(step: Step) -> None:
         step (:class:`~stagpy._step.Step`): a step of a StagyyData
             instance.
     """
+    if conf is None:
+        conf = Config.default_()
     drprof = step.rprofs["dr"]
     fig, (ax1, ax2) = plt.subplots(2, sharex=True)
     ax1.plot(drprof.rad, "-ko")
@@ -86,7 +88,7 @@ def plot_grid(step: Step) -> None:
     ax2.set_ylabel("$dr$")
     ax2.set_xlim([-0.5, len(drprof.rad) - 0.5])
     ax2.set_xlabel("Cell number")
-    _helpers.saveplot(fig, "grid", step.istep)
+    _helpers.saveplot(conf, fig, "grid", step.istep)
 
 
 def cmd() -> None:
@@ -103,7 +105,7 @@ def cmd() -> None:
 
     if conf.rprof.grid:
         for step in view.filter(rprofs=True):
-            plot_grid(step)
+            plot_grid(step, conf)
 
     if conf.rprof.average:
         plot_rprofs(view.rprofs_averaged, conf.rprof.plot, conf)

--- a/stagpy/rprof.py
+++ b/stagpy/rprof.py
@@ -31,7 +31,6 @@ def plot_rprofs(
     if conf is None:
         conf = Config.default_()
     stepstr = rprofs.stepstr
-    sdat = rprofs.step.sdat
 
     for vfig in names:
         fig, axes = plt.subplots(
@@ -48,7 +47,7 @@ def plot_rprofs(
                 rad = rpf.rad
                 meta = rpf.meta
                 if conf.rprof.depth:
-                    rad = sdat.scale(rprofs.bounds[1], "m")[0] - rad
+                    rad = rprofs.bounds[1] - rad
                 axes[iplt].plot(rprof, rad, conf.rprof.style, label=meta.description)
                 if xlabel is None:
                     xlabel = meta.kind
@@ -57,8 +56,6 @@ def plot_rprofs(
             if ivar == 0:
                 xlabel = meta.description
             if xlabel:
-                _, unit = sdat.scale(1, meta.dim)
-                xlabel += f" ({unit})" if unit else ""
                 axes[iplt].set_xlabel(xlabel)
             if vplt[0][:3] == "eta":  # list of log variables
                 axes[iplt].set_xscale("log")
@@ -68,8 +65,6 @@ def plot_rprofs(
         if conf.rprof.depth:
             axes[0].invert_yaxis()
         ylabel = "Depth" if conf.rprof.depth else "Radius"
-        _, unit = sdat.scale(1, "m")
-        ylabel += f" ({unit})" if unit else ""
         axes[0].set_ylabel(ylabel)
         _helpers.saveplot(fig, fname + stepstr)
 
@@ -84,14 +79,11 @@ def plot_grid(step: Step) -> None:
             instance.
     """
     drprof = step.rprofs["dr"]
-    _, unit = step.sdat.scale(1, "m")
-    if unit:
-        unit = f" ({unit})"
     fig, (ax1, ax2) = plt.subplots(2, sharex=True)
     ax1.plot(drprof.rad, "-ko")
-    ax1.set_ylabel("$r$" + unit)
+    ax1.set_ylabel("$r$")
     ax2.plot(drprof.values, "-ko")
-    ax2.set_ylabel("$dr$" + unit)
+    ax2.set_ylabel("$dr$")
     ax2.set_xlim([-0.5, len(drprof.rad) - 0.5])
     ax2.set_xlabel("Cell number")
     _helpers.saveplot(fig, "grid", step.istep)

--- a/stagpy/rprof.py
+++ b/stagpy/rprof.py
@@ -99,13 +99,14 @@ def cmd() -> None:
     from . import conf
 
     sdat = StagyyData(conf.core.path)
+    view = _helpers.walk(sdat, conf)
 
     if conf.rprof.grid:
-        for step in sdat.walk.filter(rprofs=True):
+        for step in view.filter(rprofs=True):
             plot_grid(step)
 
     if conf.rprof.average:
-        plot_rprofs(sdat.walk.rprofs_averaged, conf.rprof.plot, conf)
+        plot_rprofs(view.rprofs_averaged, conf.rprof.plot, conf)
     else:
-        for step in sdat.walk.filter(rprofs=True):
+        for step in view.filter(rprofs=True):
             plot_rprofs(step.rprofs, conf.rprof.plot, conf)

--- a/stagpy/rprof.py
+++ b/stagpy/rprof.py
@@ -92,12 +92,7 @@ def plot_grid(step: Step, conf: Optional[Config] = None) -> None:
 
 
 def cmd(conf: Config) -> None:
-    """Implementation of rprof subcommand.
-
-    Other Parameters:
-        conf.rprof
-        conf.core
-    """
+    """Implementation of rprof subcommand."""
     sdat = StagyyData(conf.core.path)
     view = _helpers.walk(sdat, conf)
 

--- a/stagpy/rprof.py
+++ b/stagpy/rprof.py
@@ -91,15 +91,13 @@ def plot_grid(step: Step, conf: Optional[Config] = None) -> None:
     _helpers.saveplot(conf, fig, "grid", step.istep)
 
 
-def cmd() -> None:
+def cmd(conf: Config) -> None:
     """Implementation of rprof subcommand.
 
     Other Parameters:
         conf.rprof
         conf.core
     """
-    from . import conf
-
     sdat = StagyyData(conf.core.path)
     view = _helpers.walk(sdat, conf)
 

--- a/stagpy/stagyydata.py
+++ b/stagpy/stagyydata.py
@@ -22,7 +22,6 @@ import numpy as np
 from . import _helpers, _step, conf, error, phyvars, stagyyparsers
 from ._step import Step
 from .datatypes import Rprof, Tseries, Vart
-from .dimensions import Scales
 from .parfile import StagyyPar
 from .stagyyparsers import FieldXmf, TracersXmf
 
@@ -667,7 +666,6 @@ class StagyyData:
     Attributes:
         steps (:class:`_Steps`): collection of time steps.
         snaps (:class:`_Snaps`): collection of snapshots.
-        scales (:class:`_Scales`): dimensionful scaling factors.
         refstate (:class:`_Refstate`): reference state profiles.
     """
 
@@ -675,7 +673,6 @@ class StagyyData:
         self._parpath = Path(path)
         if not self._parpath.is_file():
             self._parpath /= "par"
-        self.scales = Scales(self)
         self.refstate = _Refstate(self)
         self.tseries = _Tseries(self)
         self.steps = _Steps(self)

--- a/stagpy/stagyydata.py
+++ b/stagpy/stagyydata.py
@@ -795,42 +795,6 @@ class StagyyData:
             raise error.InvalidNfieldsError(nfields)
         self._nfields_max = nfields
 
-    @typing.overload
-    def scale(self, data: ndarray, unit: str) -> Tuple[ndarray, str]:
-        """Scale a ndarray."""
-        ...
-
-    @typing.overload
-    def scale(self, data: float, unit: str) -> Tuple[float, str]:
-        """Scale a float."""
-        ...
-
-    def scale(
-        self, data: Union[ndarray, float], unit: str
-    ) -> Tuple[Union[ndarray, float], str]:
-        """Scales quantity to obtain dimensionful quantity.
-
-        Args:
-            data: the quantity that should be scaled.
-            unit: the dimension of data as defined in phyvars.
-        Return:
-            scaled quantity and unit string.
-        """
-        if self.par.get("switches", "dimensional_units", True) or unit == "1":
-            return data, ""
-        scaling = phyvars.SCALES[unit](self.scales)
-        factor = conf.scaling.factors.get(unit, " ")
-        if conf.scaling.time_in_y and unit == "s":
-            scaling /= conf.scaling.yearins
-            unit = "yr"
-        elif conf.scaling.vel_in_cmpy and unit == "m/s":
-            scaling *= 100 * conf.scaling.yearins
-            unit = "cm/y"
-        if factor in phyvars.PREFIXES:
-            scaling *= 10 ** (-3 * (phyvars.PREFIXES.index(factor) + 1))
-            unit = factor + unit
-        return data * scaling, unit
-
     def filename(
         self,
         fname: str,

--- a/stagpy/stagyydata.py
+++ b/stagpy/stagyydata.py
@@ -142,8 +142,7 @@ class _Tseries:
 
     :class:`_Tseries` implements the getitem mechanism.  Keys are series names
     defined in :data:`stagpy.phyvars.TIME[_EXTRA]`.  Items are
-    :class:`stagpy.datatypes.Tseries` instances.  Note that series are
-    automatically scaled if conf.scaling.dimensional is True.
+    :class:`stagpy.datatypes.Tseries` instances.
 
     Attributes:
         sdat: the :class:`StagyyData` instance owning the :class:`_Tseries`
@@ -194,8 +193,6 @@ class _Tseries:
             meta = tseries.meta
         else:
             raise error.UnknownTimeVarError(name)
-        series, _ = self.sdat.scale(series, meta.dim)
-        time, _ = self.sdat.scale(time, "s")
         return Tseries(series, time, meta)
 
     def tslice(
@@ -818,15 +815,8 @@ class StagyyData:
             unit: the dimension of data as defined in phyvars.
         Return:
             scaled quantity and unit string.
-        Other Parameters:
-            conf.scaling.dimensional: if set to False (default), the factor is
-                always 1.
         """
-        if (
-            self.par.get("switches", "dimensional_units", True)
-            or not conf.scaling.dimensional
-            or unit == "1"
-        ):
+        if self.par.get("switches", "dimensional_units", True) or unit == "1":
             return data, ""
         scaling = phyvars.SCALES[unit](self.scales)
         factor = conf.scaling.factors.get(unit, " ")

--- a/stagpy/stagyydata.py
+++ b/stagpy/stagyydata.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import numpy as np
 
-from . import _helpers, _step, conf, error, phyvars, stagyyparsers
+from . import _helpers, _step, error, phyvars, stagyyparsers
 from ._step import Step
 from .datatypes import Rprof, Tseries, Vart
 from .parfile import StagyyPar
@@ -761,18 +761,6 @@ class StagyyData:
         if out_dir.is_dir():
             return set(out_dir.iterdir())
         return set()
-
-    @property
-    def walk(self) -> _StepsView:
-        """Return view on configured steps slice.
-
-        Other Parameters:
-            conf.core.snapshots: the slice of snapshots.
-            conf.core.timesteps: the slice of timesteps.
-        """
-        if conf.core.timesteps:
-            return self.steps[conf.core.timesteps]
-        return self.snaps[conf.core.snapshots]
 
     @property
     def nfields_max(self) -> Optional[int]:

--- a/stagpy/stagyydata.py
+++ b/stagpy/stagyydata.py
@@ -22,6 +22,7 @@ import numpy as np
 from . import _helpers, _step, conf, error, phyvars, stagyyparsers
 from ._step import Step
 from .datatypes import Rprof, Tseries, Vart
+from .dimensions import Scales
 from .parfile import StagyyPar
 from .stagyyparsers import FieldXmf, TracersXmf
 
@@ -71,94 +72,6 @@ def _as_view_item(
     if isinstance(obj, slice):
         return (obj,)
     return None
-
-
-class _Scales:
-    """Dimensional scales.
-
-    Args:
-        sdat: the StagyyData instance owning the :class:`_Scales` instance.
-    """
-
-    def __init__(self, sdat: StagyyData):
-        self._sdat = sdat
-
-    @property
-    def par(self) -> StagyyPar:
-        return self._sdat.par
-
-    @cached_property
-    def length(self) -> float:
-        """Length in m."""
-        thick = self.par.get("geometry", "d_dimensional", 2890e3)
-        if self.par.get("boundaries", "air_layer", False):
-            thick += self.par.nml["boundaries"]["air_thickness"]
-        return thick
-
-    @property
-    def temperature(self) -> float:
-        """Temperature in K."""
-        return self.par.nml["refstate"]["deltaT_dimensional"]
-
-    @property
-    def density(self) -> float:
-        """Density in kg/m3."""
-        return self.par.nml["refstate"]["dens_dimensional"]
-
-    @property
-    def th_cond(self) -> float:
-        """Thermal conductivity in W/(m.K)."""
-        return self.par.nml["refstate"]["tcond_dimensional"]
-
-    @property
-    def sp_heat(self) -> float:
-        """Specific heat capacity in J/(kg.K)."""
-        return self.par.nml["refstate"]["Cp_dimensional"]
-
-    @property
-    def dyn_visc(self) -> float:
-        """Dynamic viscosity in Pa.s."""
-        return self.par.nml["viscosity"]["eta0"]
-
-    @property
-    def th_diff(self) -> float:
-        """Thermal diffusivity in m2/s."""
-        return self.th_cond / (self.density * self.sp_heat)
-
-    @property
-    def time(self) -> float:
-        """Time in s."""
-        return self.length**2 / self.th_diff
-
-    @property
-    def velocity(self) -> float:
-        """Velocity in m/s."""
-        return self.length / self.time
-
-    @property
-    def acceleration(self) -> float:
-        """Acceleration in m/s2."""
-        return self.length / self.time**2
-
-    @property
-    def power(self) -> float:
-        """Power in W."""
-        return self.th_cond * self.temperature * self.length
-
-    @property
-    def heat_flux(self) -> float:
-        """Local heat flux in W/m2."""
-        return self.power / self.length**2
-
-    @property
-    def heat_production(self) -> float:
-        """Local heat production in W/m3."""
-        return self.power / self.length**3
-
-    @property
-    def stress(self) -> float:
-        """Stress in Pa."""
-        return self.dyn_visc / self.time
 
 
 class _Refstate:
@@ -765,7 +678,7 @@ class StagyyData:
         self._parpath = Path(path)
         if not self._parpath.is_file():
             self._parpath /= "par"
-        self.scales = _Scales(self)
+        self.scales = Scales(self)
         self.refstate = _Refstate(self)
         self.tseries = _Tseries(self)
         self.steps = _Steps(self)

--- a/stagpy/time_series.py
+++ b/stagpy/time_series.py
@@ -124,15 +124,13 @@ def compstat(
     return stats
 
 
-def cmd() -> None:
+def cmd(conf: Config) -> None:
     """Implementation of time subcommand.
 
     Other Parameters:
         conf.time
         conf.core
     """
-    from . import conf
-
     sdat = StagyyData(conf.core.path)
     if sdat.tseries is None:
         return

--- a/stagpy/time_series.py
+++ b/stagpy/time_series.py
@@ -91,7 +91,7 @@ def plot_time_series(
         axes[-1].set_xlabel("Time")
         axes[-1].set_xlim(tstart, tend)
         axes[-1].tick_params()
-        _helpers.saveplot(fig, "_".join(fname))
+        _helpers.saveplot(conf, fig, "_".join(fname))
 
 
 def compstat(

--- a/stagpy/time_series.py
+++ b/stagpy/time_series.py
@@ -79,9 +79,6 @@ def plot_time_series(
             if ivar == 0:
                 ylabel = tseries.meta.description
             if ylabel:
-                _, unit = sdat.scale(1, tseries.meta.dim)
-                if unit:
-                    ylabel += f" ({unit})"
                 axes[iplt].set_ylabel(ylabel)
             if vplt[0][:3] == "eta":  # list of log variables
                 axes[iplt].set_yscale("log")
@@ -91,10 +88,7 @@ def plot_time_series(
             axes[iplt].tick_params()
             for time_mark in time_marks:
                 axes[iplt].axvline(time_mark, color="black", linestyle="--")
-        _, unit = sdat.scale(1, "s")
-        if unit:
-            unit = f" ({unit})"
-        axes[-1].set_xlabel("Time" + unit)
+        axes[-1].set_xlabel("Time")
         axes[-1].set_xlim(tstart, tend)
         axes[-1].tick_params()
         _helpers.saveplot(fig, "_".join(fname))

--- a/stagpy/time_series.py
+++ b/stagpy/time_series.py
@@ -37,10 +37,6 @@ def plot_time_series(
     Args:
         sdat: a :class:`~stagpy.stagyydata.StagyyData` instance.
         names: time series names organized by figures, plots and subplots.
-
-    Other Parameters:
-        conf.time.tstart: the starting time.
-        conf.time.tend: the ending time.
     """
     if conf is None:
         conf = Config.default_()
@@ -125,12 +121,7 @@ def compstat(
 
 
 def cmd(conf: Config) -> None:
-    """Implementation of time subcommand.
-
-    Other Parameters:
-        conf.time
-        conf.core
-    """
+    """Implementation of time subcommand."""
     sdat = StagyyData(conf.core.path)
     if sdat.tseries is None:
         return

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -3,11 +3,14 @@ import re
 import pytest
 from pytest import CaptureFixture
 
-import stagpy.args
+import stagpy
+from stagpy.args import parse_args
+from stagpy.config import Config
 
 
 def test_no_args(capsys: CaptureFixture) -> None:
-    stagpy.args.parse_args([])()
+    conf = Config.default_()
+    parse_args(conf, [])(conf)
     output = capsys.readouterr()
     expected = re.compile(
         r"StagPy is a tool to.*" r"Run `stagpy -h` for usage\n$", flags=re.DOTALL
@@ -16,8 +19,9 @@ def test_no_args(capsys: CaptureFixture) -> None:
 
 
 def test_help(capsys: CaptureFixture) -> None:
+    conf = Config.default_()
     with pytest.raises(SystemExit):
-        stagpy.args.parse_args(["-h"])
+        parse_args(conf, ["-h"])
     output = capsys.readouterr()
     expected = re.compile(
         r"^usage:.*\nStagPy is a tool to.*\n"
@@ -29,8 +33,9 @@ def test_help(capsys: CaptureFixture) -> None:
 
 
 def test_invalid_argument(capsys: CaptureFixture) -> None:
+    conf = Config.default_()
     with pytest.raises(SystemExit):
-        stagpy.args.parse_args(["-dummyinvalidarg"])
+        parse_args(conf, ["-dummyinvalidarg"])
     output = capsys.readouterr()
     expected = re.compile(
         r"^usage: .*error: unrecognized arguments:.*\n$", flags=re.DOTALL
@@ -39,48 +44,57 @@ def test_invalid_argument(capsys: CaptureFixture) -> None:
 
 
 def test_invalid_subcmd(capsys: CaptureFixture) -> None:
+    conf = Config.default_()
     with pytest.raises(SystemExit):
-        stagpy.args.parse_args(["dummyinvalidcmd"])
+        parse_args(conf, ["dummyinvalidcmd"])
     output = capsys.readouterr()
     expected = re.compile(r"^usage: .*error:.*invalid choice:.*\n$", flags=re.DOTALL)
     assert expected.fullmatch(output.err)
 
 
 def test_field_subcmd() -> None:
-    func = stagpy.args.parse_args(["field"])
+    conf = Config.default_()
+    func = parse_args(conf, ["field"])
     assert func is stagpy.field.cmd
 
 
 def test_rprof_subcmd() -> None:
-    func = stagpy.args.parse_args(["rprof"])
+    conf = Config.default_()
+    func = parse_args(conf, ["rprof"])
     assert func is stagpy.rprof.cmd
 
 
 def test_time_cmd() -> None:
-    func = stagpy.args.parse_args(["time"])
+    conf = Config.default_()
+    func = parse_args(conf, ["time"])
     assert func is stagpy.time_series.cmd
 
 
 def test_plates_subcmd() -> None:
-    func = stagpy.args.parse_args(["plates"])
+    conf = Config.default_()
+    func = parse_args(conf, ["plates"])
     assert func is stagpy.plates.cmd
 
 
 def test_info_subcmd() -> None:
-    func = stagpy.args.parse_args(["info"])
+    conf = Config.default_()
+    func = parse_args(conf, ["info"])
     assert func is stagpy.commands.info_cmd
 
 
 def test_var_subcmd() -> None:
-    func = stagpy.args.parse_args(["var"])
+    conf = Config.default_()
+    func = parse_args(conf, ["var"])
     assert func is stagpy.commands.var_cmd
 
 
 def test_version_subcmd() -> None:
-    func = stagpy.args.parse_args(["version"])
+    conf = Config.default_()
+    func = parse_args(conf, ["version"])
     assert func is stagpy.commands.version_cmd
 
 
 def test_config_subcmd() -> None:
-    func = stagpy.args.parse_args(["config"])
+    conf = Config.default_()
+    func = parse_args(conf, ["config"])
     assert func is stagpy.commands.config_cmd

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,36 +3,37 @@ from pathlib import Path
 
 from pytest import CaptureFixture
 
-import stagpy.commands
+from stagpy import __version__, commands
+from stagpy.config import Config
 
 
 def test_info_cmd(capsys: CaptureFixture, example_dir: Path) -> None:
-    stagpy.conf.core.path = example_dir
-    stagpy.commands.info_cmd()
+    conf = Config.default_()
+    conf.core.path = example_dir
+    commands.info_cmd(conf)
     output = capsys.readouterr()
     expected = re.compile(
         r"^StagYY run in.*\n.* x .*\n\nStep.*, snapshot.*\n  t.*\n\n$", flags=re.DOTALL
     )
     assert expected.fullmatch(output.out)
-    del stagpy.conf.core.path
 
 
 def test_var_cmd(capsys: CaptureFixture) -> None:
-    stagpy.commands.var_cmd()
+    commands.var_cmd(Config.default_())
     output = capsys.readouterr()
     expected = re.compile(r"field:\n.*\nrprof:\n.*\ntime:\n.*\n.*$", flags=re.DOTALL)
     assert expected.fullmatch(output.out)
 
 
 def test_version_cmd(capsys: CaptureFixture) -> None:
-    stagpy.commands.version_cmd()
+    commands.version_cmd(Config.default_())
     output = capsys.readouterr()
-    expected = "stagpy version: {}\n".format(stagpy.__version__)
+    expected = "stagpy version: {}\n".format(__version__)
     assert output.out == expected
 
 
 def test_config_cmd(capsys: CaptureFixture) -> None:
-    stagpy.commands.config_cmd()
+    commands.config_cmd(Config.default_())
     output = capsys.readouterr()
     expected = "(c|f): available only as CLI argument/in the config file"
     assert output.out.startswith(expected)

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,8 +1,9 @@
 import pytest
 
 import stagpy.error
-import stagpy.field
 import stagpy.phyvars
+from stagpy.config import Config
+from stagpy.field import get_meshes_fld, get_meshes_vec, valid_field_var
 from stagpy.stagyydata import Step
 
 
@@ -20,17 +21,17 @@ def test_field_missing(step: Step) -> None:
 
 def test_valid_field_var() -> None:
     for var in stagpy.phyvars.FIELD:
-        assert stagpy.field.valid_field_var(var)
+        assert valid_field_var(var)
     for var in stagpy.phyvars.FIELD_EXTRA:
-        assert stagpy.field.valid_field_var(var)
+        assert valid_field_var(var)
 
 
 def test_valid_field_var_invalid() -> None:
-    assert not stagpy.field.valid_field_var("dummyfieldvar")
+    assert not valid_field_var("dummyfieldvar")
 
 
 def test_get_meshes_fld_no_walls(step: Step) -> None:
-    xmesh, ymesh, fld, meta = stagpy.field.get_meshes_fld(step, "T", walls=False)
+    xmesh, ymesh, fld, meta = get_meshes_fld(Config.default_(), step, "T", walls=False)
     assert len(fld.shape) == 2
     assert xmesh.shape[0] == ymesh.shape[0] == fld.shape[0]
     assert xmesh.shape[1] == ymesh.shape[1] == fld.shape[1]
@@ -38,7 +39,7 @@ def test_get_meshes_fld_no_walls(step: Step) -> None:
 
 
 def test_get_meshes_fld_walls(step: Step) -> None:
-    xmesh, ymesh, fld, meta = stagpy.field.get_meshes_fld(step, "T", walls=True)
+    xmesh, ymesh, fld, meta = get_meshes_fld(Config.default_(), step, "T", walls=True)
     assert len(fld.shape) == 2
     assert xmesh.shape[0] == ymesh.shape[0] == fld.shape[0] + 1
     assert xmesh.shape[1] == ymesh.shape[1] == fld.shape[1] + 1
@@ -46,7 +47,7 @@ def test_get_meshes_fld_walls(step: Step) -> None:
 
 
 def test_get_meshes_vec(step: Step) -> None:
-    xmesh, ymesh, vec1, vec2 = stagpy.field.get_meshes_vec(step, "v")
+    xmesh, ymesh, vec1, vec2 = get_meshes_vec(Config.default_(), step, "v")
     assert len(vec1.shape) == 2
     assert xmesh.shape[0] == ymesh.shape[0] == vec1.shape[0] == vec2.shape[0]
     assert xmesh.shape[1] == ymesh.shape[1] == vec1.shape[1] == vec2.shape[1]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,5 @@
 import pytest
 
-import stagpy
 from stagpy import _helpers
 from stagpy.config import Config
 from stagpy.stagyydata import StagyyData
@@ -15,15 +14,16 @@ def test_walk_dflt(sdat: StagyyData) -> None:
 
 
 def test_out_name_conf() -> None:
+    conf = Config.default_()
     oname = "something_fancy"
-    stagpy.conf.core.outname = oname
+    conf.core.outname = oname
     stem = "teapot"
-    assert _helpers.out_name(stem) == oname + "_" + stem
-    del stagpy.conf.core.outname
+    assert _helpers.out_name(conf, stem) == oname + "_" + stem
 
 
 def test_out_name_number() -> None:
-    assert _helpers.out_name("T", 123) == "stagpy_T00123"
+    conf = Config.default_()
+    assert _helpers.out_name(conf, "T", 123) == "stagpy_T00123"
 
 
 def test_baredoc() -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,7 +1,6 @@
 import pytest
 
 import stagpy
-import stagpy._helpers
 from stagpy import _helpers
 from stagpy.config import Config
 from stagpy.stagyydata import StagyyData
@@ -19,12 +18,12 @@ def test_out_name_conf() -> None:
     oname = "something_fancy"
     stagpy.conf.core.outname = oname
     stem = "teapot"
-    assert stagpy._helpers.out_name(stem) == oname + "_" + stem
+    assert _helpers.out_name(stem) == oname + "_" + stem
     del stagpy.conf.core.outname
 
 
 def test_out_name_number() -> None:
-    assert stagpy._helpers.out_name("T", 123) == "stagpy_T00123"
+    assert _helpers.out_name("T", 123) == "stagpy_T00123"
 
 
 def test_baredoc() -> None:
@@ -35,4 +34,4 @@ def test_baredoc() -> None:
 
     """
     expected = "Badly formatted docstring"
-    assert stagpy._helpers.baredoc(test_baredoc) == expected
+    assert _helpers.baredoc(test_baredoc) == expected

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,18 @@
+import pytest
+
 import stagpy
 import stagpy._helpers
+from stagpy import _helpers
+from stagpy.config import Config
+from stagpy.stagyydata import StagyyData
+
+
+def test_walk_dflt(sdat: StagyyData) -> None:
+    view = _helpers.walk(sdat, Config.default_())
+    wlk = iter(view)
+    assert next(wlk) is sdat.snaps[-1]
+    with pytest.raises(StopIteration):
+        next(wlk)
 
 
 def test_out_name_conf() -> None:

--- a/tests/test_stagyydata.py
+++ b/tests/test_stagyydata.py
@@ -35,13 +35,6 @@ def test_sdat_tseries(sdat: StagyyData) -> None:
     assert sdat.tseries["Tmean"].time is sdat.tseries.time
 
 
-def test_sdat_walk_dflt(sdat: StagyyData) -> None:
-    wlk = iter(sdat.walk)
-    assert next(wlk) is sdat.snaps[-1]
-    with pytest.raises(StopIteration):
-        next(wlk)
-
-
 def test_steps_iter(sdat: StagyyData) -> None:
     assert sdat.steps[:] == sdat.steps
 


### PR DESCRIPTION
In preparation to make StagPy more modular, this PR removes the global `conf` variable. This makes the dependency of various functions on configuration variables explicit, and hence easier to manage. `scaling.dimensional` is removed along with `StagyyData.scales` and `StagyyData.scale()`, to avoid silently making variables dimensional in user scripts. You can now use `dimensions.Scales.make_dimensional()` to explicitly make values dimensional in scripts.